### PR TITLE
feat: add UV island-aware painting, face brush, gradient tool, and preview overlays

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto
+
+*.asmdef text eol=lf
+*.cs text eol=lf
+*.json text eol=lf
+*.meta text eol=lf
+*.po text eol=lf
+*.rsp text eol=lf
+*.shader text eol=lf

--- a/Packages/net.nekobako.mask-texture-editor/Editor/MeshUvData.cs
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/MeshUvData.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+namespace net.nekobako.MaskTextureEditor.Editor
+{
+    internal sealed class MeshUvData
+    {
+        public Vector2[] Points { get; }
+        public int[] LineIndices { get; }
+        public int[]? TriangleIndices { get; }
+        public Color[]? NormalColors { get; }
+        public UvTopology? Topology { get; }
+
+        public MeshUvData(
+            Vector2[] points,
+            int[] lineIndices,
+            int[]? triangleIndices,
+            Color[]? normalColors)
+        {
+            Points = points;
+            LineIndices = lineIndices;
+            TriangleIndices = triangleIndices;
+            NormalColors = normalColors;
+            Topology = triangleIndices != null ? new(points, triangleIndices) : null;
+        }
+    }
+}

--- a/Packages/net.nekobako.mask-texture-editor/Editor/MeshUvData.cs.meta
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/MeshUvData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d93e14ec417b45ec8f89c86cccf74222

--- a/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/Fill.shader
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/Fill.shader
@@ -3,7 +3,10 @@ Shader "Hidden/MaskTextureEditor/Fill"
     Properties
     {
         _ColorMask("Color Mask", Int) = 15
+        _MainTex("Texture", 2D) = "white" {}
         _Color("Color", Color) = (1.0, 1.0, 1.0, 1.0)
+        _SelectionMask("Selection Mask", 2D) = "white" {}
+        _UseSelectionMask("Use Selection Mask", Float) = 0.0
     }
 
     SubShader
@@ -23,16 +26,36 @@ Shader "Hidden/MaskTextureEditor/Fill"
 
             #include "UnityCG.cginc"
 
-            float4 _Color;
-
-            float4 vert(float4 v : POSITION) : SV_POSITION
+            struct appdata
             {
-                return UnityObjectToClipPos(v);
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+            float4 _Color;
+            sampler2D _SelectionMask;
+            float _UseSelectionMask;
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+                return o;
             }
 
-            float4 frag() : SV_Target
+            float4 frag(v2f i) : SV_Target
             {
-                return _Color;
+                float selection = lerp(1.0, tex2D(_SelectionMask, i.uv).r, _UseSelectionMask);
+                return lerp(tex2D(_MainTex, i.uv), _Color, selection);
             }
             ENDCG
         }

--- a/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/Gradient.shader
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/Gradient.shader
@@ -1,0 +1,110 @@
+Shader "Hidden/MaskTextureEditor/Gradient"
+{
+    Properties
+    {
+        _ColorMask("Color Mask", Int) = 15
+        _MainTex("Texture", 2D) = "white" {}
+        _SelectionMask("Selection Mask", 2D) = "black" {}
+        _UseSelectionMask("Use Selection Mask", Float) = 0.0
+        _StartPoint("Start Point", Vector) = (0.0, 0.0, 0.0, 0.0)
+        _EndPoint("End Point", Vector) = (1.0, 0.0, 0.0, 0.0)
+        _StartValue("Start Value", Float) = 0.0
+        _EndValue("End Value", Float) = 1.0
+        _CurveExponent("Curve Exponent", Float) = 1.0
+        _TextureSize("Texture Size", Vector) = (1.0, 1.0, 0.0, 0.0)
+        _GradientShape("Gradient Shape", Int) = 0
+        _GradientWidth("Gradient Width", Float) = 128.0
+        _GradientFeather("Gradient Feather", Float) = 32.0
+    }
+
+    SubShader
+    {
+        Tags
+        {
+            "RenderType" = "Opaque"
+        }
+
+        Pass
+        {
+            ColorMask [_ColorMask]
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+            sampler2D _SelectionMask;
+            float _UseSelectionMask;
+            float2 _StartPoint;
+            float2 _EndPoint;
+            float _StartValue;
+            float _EndValue;
+            float _CurveExponent;
+            float2 _TextureSize;
+            int _GradientShape;
+            float _GradientWidth;
+            float _GradientFeather;
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float2 pixel = i.uv * _TextureSize;
+                float2 start = _StartPoint * _TextureSize;
+                float2 end = _EndPoint * _TextureSize;
+                float2 direction = end - start;
+                float lengthSquared = max(dot(direction, direction), 1e-8);
+                float rawT = dot(pixel - start, direction) / lengthSquared;
+                float t = saturate(rawT);
+                float shapeMask = 1.0;
+                if (_GradientShape == 1)
+                {
+                    float2 closest = start + direction * t;
+                    float distanceToBand = length(pixel - closest);
+                    float halfWidth = max(_GradientWidth * 0.5, 0.0);
+                    float feather = max(_GradientFeather, 1e-4);
+                    float segmentMask = step(0.0, rawT) * step(rawT, 1.0);
+                    shapeMask = (1.0 - smoothstep(halfWidth, halfWidth + feather, distanceToBand)) * segmentMask;
+                }
+                else if (_GradientShape == 2)
+                {
+                    float radius = max(length(direction), 1e-4);
+                    float distanceToCenter = length(pixel - start);
+                    t = saturate(distanceToCenter / radius);
+                    float feather = max(_GradientFeather, 1e-4);
+                    shapeMask = 1.0 - smoothstep(radius, radius + feather, distanceToCenter);
+                }
+                float exponent = max(_CurveExponent, 1e-4);
+                float curveStart = pow(t, exponent);
+                float curveEnd = pow(1.0 - t, exponent);
+                t = curveStart / max(curveStart + curveEnd, 1e-6);
+                float value = lerp(_StartValue, _EndValue, t);
+                float selection = lerp(1.0, tex2D(_SelectionMask, i.uv).r, _UseSelectionMask) * shapeMask;
+                float strength = saturate(value) * selection;
+                return lerp(tex2D(_MainTex, i.uv), float4(1.0, 1.0, 1.0, 1.0), strength);
+            }
+            ENDCG
+        }
+    }
+}

--- a/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/Gradient.shader
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/Gradient.shader
@@ -14,7 +14,7 @@ Shader "Hidden/MaskTextureEditor/Gradient"
         _TextureSize("Texture Size", Vector) = (1.0, 1.0, 0.0, 0.0)
         _GradientShape("Gradient Shape", Int) = 0
         _GradientWidth("Gradient Width", Float) = 128.0
-        _GradientFeather("Gradient Feather", Float) = 32.0
+        _GradientFeather("Gradient Feather", Float) = 0.2
     }
 
     SubShader
@@ -85,7 +85,7 @@ Shader "Hidden/MaskTextureEditor/Gradient"
                     float halfWidth = max(_GradientWidth * 0.5, 0.0);
                     float feather = max(_GradientFeather, 1e-4);
                     float segmentMask = step(0.0, rawT) * step(rawT, 1.0);
-                    shapeMask = (1.0 - smoothstep(halfWidth, halfWidth + feather, distanceToBand)) * segmentMask;
+                    shapeMask = (1.0 - smoothstep(halfWidth, halfWidth * (1.0 + feather), distanceToBand)) * segmentMask;
                 }
                 else if (_GradientShape == 2)
                 {
@@ -93,16 +93,16 @@ Shader "Hidden/MaskTextureEditor/Gradient"
                     float distanceToCenter = length(pixel - start);
                     t = saturate(distanceToCenter / radius);
                     float feather = max(_GradientFeather, 1e-4);
-                    shapeMask = 1.0 - smoothstep(radius, radius + feather, distanceToCenter);
+                    shapeMask = 1.0 - smoothstep(radius, radius * (1.0 + feather), distanceToCenter);
                 }
                 float exponent = max(_CurveExponent, 1e-4);
                 float curveStart = pow(t, exponent);
                 float curveEnd = pow(1.0 - t, exponent);
                 t = curveStart / max(curveStart + curveEnd, 1e-6);
-                float value = lerp(_StartValue, _EndValue, t);
+                float value = saturate(lerp(_StartValue, _EndValue, t));
                 float selection = lerp(1.0, tex2D(_SelectionMask, i.uv).r, _UseSelectionMask) * shapeMask;
-                float strength = saturate(value) * selection;
-                return lerp(tex2D(_MainTex, i.uv), float4(1.0, 1.0, 1.0, 1.0), strength);
+                float4 color = tex2D(_MainTex, i.uv);
+                return lerp(color, float4(value, value, value, 1.0), selection);
             }
             ENDCG
         }

--- a/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/Gradient.shader.meta
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/Gradient.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 32c0c3b724024b05b77eb6b2debb6502
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/Inverse.shader
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/Inverse.shader
@@ -4,6 +4,8 @@ Shader "Hidden/MaskTextureEditor/Inverse"
     {
         _ColorMask("Color Mask", Int) = 15
         _MainTex("Texture", 2D) = "white" {}
+        _SelectionMask("Selection Mask", 2D) = "white" {}
+        _UseSelectionMask("Use Selection Mask", Float) = 0.0
     }
 
     SubShader
@@ -37,6 +39,8 @@ Shader "Hidden/MaskTextureEditor/Inverse"
 
             sampler2D _MainTex;
             float4 _MainTex_ST;
+            sampler2D _SelectionMask;
+            float _UseSelectionMask;
 
             v2f vert(appdata v)
             {
@@ -49,7 +53,9 @@ Shader "Hidden/MaskTextureEditor/Inverse"
             float4 frag(v2f i) : SV_Target
             {
                 float4 color = tex2D(_MainTex, i.uv);
-                return float4(1.0 - color.rgb, color.a);
+                float4 inverse = float4(1.0 - color.rgb, color.a);
+                float selection = lerp(1.0, tex2D(_SelectionMask, i.uv).r, _UseSelectionMask);
+                return lerp(color, inverse, selection);
             }
             ENDCG
         }

--- a/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/NormalOverlay.shader
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/NormalOverlay.shader
@@ -1,0 +1,49 @@
+Shader "Hidden/MaskTextureEditor/NormalOverlay"
+{
+    SubShader
+    {
+        Tags
+        {
+            "RenderType" = "Opaque"
+        }
+
+        Pass
+        {
+            Cull Off
+            ZTest Always
+            ZWrite Off
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float4 color : COLOR;
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float4 color : COLOR;
+            };
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.color = v.color;
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                return i.color;
+            }
+            ENDCG
+        }
+    }
+}

--- a/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/NormalOverlay.shader.meta
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/NormalOverlay.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: f28d5a8e76f54bf2a0b6a195ba704d5f
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/Paint.shader
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/Paint.shader
@@ -9,6 +9,8 @@ Shader "Hidden/MaskTextureEditor/Paint"
         _BrushStrength("Brush Strength", Float) = 1.0
         _BrushColor("Brush Color", Color) = (1.0, 1.0, 1.0, 1.0)
         _BrushPosition("Brush Position", Vector) = (0.5, 0.5, 0.0, 0.0)
+        _SelectionMask("Selection Mask", 2D) = "white" {}
+        _UseSelectionMask("Use Selection Mask", Float) = 0.0
     }
 
     SubShader
@@ -49,6 +51,8 @@ Shader "Hidden/MaskTextureEditor/Paint"
             float _BrushStrength;
             float4 _BrushColor;
             float2 _BrushPosition;
+            sampler2D _SelectionMask;
+            float _UseSelectionMask;
 
             v2f vert(appdata v)
             {
@@ -62,7 +66,9 @@ Shader "Hidden/MaskTextureEditor/Paint"
             {
                 float r = _BrushSize * _MainTex_TexelSize.xy * 0.5;
                 float d = distance(i.uv, _BrushPosition.xy * _MainTex_TexelSize.xy);
-                return lerp(tex2D(_MainTex, i.uv), _BrushColor, (1.0 - smoothstep(r * _BrushHardness, r, d)) * _BrushStrength);
+                float selection = lerp(1.0, tex2D(_SelectionMask, i.uv).r, _UseSelectionMask);
+                float strength = (1.0 - smoothstep(r * _BrushHardness, r, d)) * _BrushStrength * selection;
+                return lerp(tex2D(_MainTex, i.uv), _BrushColor, strength);
             }
             ENDCG
         }

--- a/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/SelectionOverlay.shader
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/SelectionOverlay.shader
@@ -1,0 +1,34 @@
+Shader "Hidden/MaskTextureEditor/SelectionOverlay"
+{
+    SubShader
+    {
+        Tags
+        {
+            "RenderType" = "Opaque"
+        }
+
+        Pass
+        {
+            Cull Off
+            ZTest Always
+            ZWrite Off
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            float4 vert(float4 vertex : POSITION) : SV_POSITION
+            {
+                return UnityObjectToClipPos(vertex);
+            }
+
+            float4 frag() : SV_Target
+            {
+                return 1.0;
+            }
+            ENDCG
+        }
+    }
+}

--- a/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/SelectionOverlay.shader.meta
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/SelectionOverlay.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 419d29c77a8e4116a4144c504376d3ef
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/TrianglePaint.shader
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/TrianglePaint.shader
@@ -1,0 +1,87 @@
+Shader "Hidden/MaskTextureEditor/TrianglePaint"
+{
+    Properties
+    {
+        _ColorMask("Color Mask", Int) = 15
+        _MainTex("Texture", 2D) = "white" {}
+        _TriangleMask("Triangle Mask", 2D) = "black" {}
+        _BrushStrength("Brush Strength", Float) = 1.0
+        _BrushColor("Brush Color", Color) = (1.0, 1.0, 1.0, 1.0)
+    }
+
+    SubShader
+    {
+        Tags
+        {
+            "RenderType" = "Transparent"
+        }
+
+        Pass
+        {
+            Cull Off
+            ZTest Always
+            ZWrite Off
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            float4 vert(float4 vertex : POSITION) : SV_POSITION
+            {
+                return UnityObjectToClipPos(vertex);
+            }
+
+            float4 frag() : SV_Target
+            {
+                return 1.0;
+            }
+            ENDCG
+        }
+
+        Pass
+        {
+            ColorMask [_ColorMask]
+
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+            sampler2D _TriangleMask;
+            float _BrushStrength;
+            float4 _BrushColor;
+
+            v2f vert(appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+                return o;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                float strength = tex2D(_TriangleMask, i.uv).r * _BrushStrength;
+                return lerp(tex2D(_MainTex, i.uv), _BrushColor, strength);
+            }
+            ENDCG
+        }
+    }
+}

--- a/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/TrianglePaint.shader
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/TrianglePaint.shader
@@ -5,6 +5,8 @@ Shader "Hidden/MaskTextureEditor/TrianglePaint"
         _ColorMask("Color Mask", Int) = 15
         _MainTex("Texture", 2D) = "white" {}
         _TriangleMask("Triangle Mask", 2D) = "black" {}
+        _SelectionMask("Selection Mask", 2D) = "white" {}
+        _UseSelectionMask("Use Selection Mask", Float) = 0.0
         _BrushStrength("Brush Strength", Float) = 1.0
         _BrushColor("Brush Color", Color) = (1.0, 1.0, 1.0, 1.0)
     }
@@ -65,6 +67,8 @@ Shader "Hidden/MaskTextureEditor/TrianglePaint"
             sampler2D _MainTex;
             float4 _MainTex_ST;
             sampler2D _TriangleMask;
+            sampler2D _SelectionMask;
+            float _UseSelectionMask;
             float _BrushStrength;
             float4 _BrushColor;
 
@@ -78,7 +82,8 @@ Shader "Hidden/MaskTextureEditor/TrianglePaint"
 
             float4 frag(v2f i) : SV_Target
             {
-                float strength = tex2D(_TriangleMask, i.uv).r * _BrushStrength;
+                float selection = lerp(1.0, tex2D(_SelectionMask, i.uv).r, _UseSelectionMask);
+                float strength = tex2D(_TriangleMask, i.uv).r * _BrushStrength * selection;
                 return lerp(tex2D(_MainTex, i.uv), _BrushColor, strength);
             }
             ENDCG

--- a/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/TrianglePaint.shader.meta
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/Shaders/TrianglePaint.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 54c81e3a55764929a1e741ee77aef05b
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/net.nekobako.mask-texture-editor/Editor/TexturePainter.cs
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/TexturePainter.cs
@@ -1,13 +1,123 @@
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Rendering;
 
 namespace net.nekobako.MaskTextureEditor.Editor
 {
+    internal enum BrushMode
+    {
+        Circle,
+        Triangle,
+    }
+
     internal class TexturePainter : ScriptableObject
     {
+        private sealed class TriangleLookup
+        {
+            private const int k_GridSize = 32;
+
+            public readonly Vector2[] Points;
+            public readonly int[] Indices;
+            public readonly Vector2[] PixelPoints;
+            public readonly List<int>[] Grid;
+            public readonly int[] VisitStamps;
+            public readonly Vector2 TextureSize;
+
+            private int m_VisitStamp = 0;
+
+            public TriangleLookup(Vector2[] points, int[] indices, Vector2 textureSize)
+            {
+                Points = points;
+                Indices = indices;
+                TextureSize = textureSize;
+                PixelPoints = new Vector2[points.Length];
+                Grid = new List<int>[k_GridSize * k_GridSize];
+                VisitStamps = new int[indices.Length / 3];
+
+                for (var i = 0; i < points.Length; i++)
+                {
+                    PixelPoints[i] = new(points[i].x * textureSize.x, (1.0f - points[i].y) * textureSize.y);
+                }
+
+                for (var offset = 0; offset + 2 < indices.Length; offset += 3)
+                {
+                    var indexA = indices[offset];
+                    var indexB = indices[offset + 1];
+                    var indexC = indices[offset + 2];
+                    if (indexA < 0 || indexA >= points.Length ||
+                        indexB < 0 || indexB >= points.Length ||
+                        indexC < 0 || indexC >= points.Length)
+                    {
+                        continue;
+                    }
+
+                    var min = Vector2.Min(points[indexA], Vector2.Min(points[indexB], points[indexC]));
+                    var max = Vector2.Max(points[indexA], Vector2.Max(points[indexB], points[indexC]));
+                    var minX = ToGrid(min.x);
+                    var minY = ToGrid(min.y);
+                    var maxX = ToGrid(max.x);
+                    var maxY = ToGrid(max.y);
+                    for (var y = minY; y <= maxY; y++)
+                    {
+                        for (var x = minX; x <= maxX; x++)
+                        {
+                            var cell = y * k_GridSize + x;
+                            Grid[cell] ??= new();
+                            Grid[cell].Add(offset);
+                        }
+                    }
+                }
+            }
+
+            public void CollectCandidates(Vector2 center, float radius, Vector2 textureSize, List<int> candidates)
+            {
+                candidates.Clear();
+
+                if (++m_VisitStamp == int.MaxValue)
+                {
+                    System.Array.Clear(VisitStamps, 0, VisitStamps.Length);
+                    m_VisitStamp = 1;
+                }
+
+                var minX = ToGrid((center.x - radius) / textureSize.x);
+                var minY = ToGrid(1.0f - (center.y + radius) / textureSize.y);
+                var maxX = ToGrid((center.x + radius) / textureSize.x);
+                var maxY = ToGrid(1.0f - (center.y - radius) / textureSize.y);
+                for (var y = minY; y <= maxY; y++)
+                {
+                    for (var x = minX; x <= maxX; x++)
+                    {
+                        var entries = Grid[y * k_GridSize + x];
+                        if (entries == null)
+                        {
+                            continue;
+                        }
+
+                        foreach (var offset in entries)
+                        {
+                            var triangle = offset / 3;
+                            if (VisitStamps[triangle] == m_VisitStamp)
+                            {
+                                continue;
+                            }
+
+                            VisitStamps[triangle] = m_VisitStamp;
+                            candidates.Add(offset);
+                        }
+                    }
+                }
+            }
+
+            private static int ToGrid(float value)
+            {
+                return Mathf.Clamp(Mathf.FloorToInt(value * k_GridSize), 0, k_GridSize - 1);
+            }
+        }
+
         private const string k_FillShaderName = "Hidden/MaskTextureEditor/Fill";
         private const string k_PaintShaderName = "Hidden/MaskTextureEditor/Paint";
+        private const string k_TrianglePaintShaderName = "Hidden/MaskTextureEditor/TrianglePaint";
         private const string k_InverseShaderName = "Hidden/MaskTextureEditor/Inverse";
 
         private static readonly int s_ColorMaskPropertyId = Shader.PropertyToID("_ColorMask");
@@ -17,6 +127,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
         private static readonly int s_BrushStrengthPropertyId = Shader.PropertyToID("_BrushStrength");
         private static readonly int s_BrushColorPropertyId = Shader.PropertyToID("_BrushColor");
         private static readonly int s_BrushPositionPropertyId = Shader.PropertyToID("_BrushPosition");
+        private static readonly int s_TriangleMaskPropertyId = Shader.PropertyToID("_TriangleMask");
 
         [SerializeField]
         private RenderTexture m_Target = null!; // Initialize in Init
@@ -25,13 +136,22 @@ namespace net.nekobako.MaskTextureEditor.Editor
         private RenderTexture m_Buffer = null!; // Initialize in Init
 
         [SerializeField]
+        private RenderTexture m_TriangleMask = null!; // Initialize in Init
+
+        [SerializeField]
         private Material m_FillMaterial = null!; // Initialize in Init
 
         [SerializeField]
         private Material m_PaintMaterial = null!; // Initialize in Init
 
         [SerializeField]
+        private Material m_TrianglePaintMaterial = null!; // Initialize in Init
+
+        [SerializeField]
         private Material m_InverseMaterial = null!; // Initialize in Init
+
+        [SerializeField]
+        private BrushMode m_BrushMode = BrushMode.Circle;
 
         [SerializeField]
         private ColorWriteMask m_ColorMask = ColorWriteMask.All;
@@ -52,9 +172,20 @@ namespace net.nekobako.MaskTextureEditor.Editor
         private Color m_BrushColor = Color.black;
 
         private Vector2 m_BrushPosition = Vector2.zero;
+        private readonly HashSet<int> m_PaintedTriangles = new();
+        private readonly List<int> m_TriangleCandidates = new();
+        private readonly List<int> m_HitTriangles = new();
+        private TriangleLookup? m_TriangleLookup = null;
+        private bool m_StrokeModified = false;
 
         public RenderTexture Texture => m_Target;
         public Vector2 TextureSize => new(m_Target.width, m_Target.height);
+
+        public BrushMode BrushMode
+        {
+            get => m_BrushMode;
+            set => m_BrushMode = value;
+        }
 
         public ColorWriteMask ColorMask
         {
@@ -121,11 +252,21 @@ namespace net.nekobako.MaskTextureEditor.Editor
             {
                 hideFlags = HideFlags.HideAndDontSave,
             };
+            m_TriangleMask = new(size.x, size.y, 0, RenderTextureFormat.R8)
+            {
+                hideFlags = HideFlags.HideAndDontSave,
+                filterMode = FilterMode.Point,
+                wrapMode = TextureWrapMode.Clamp,
+            };
             m_FillMaterial = new(Shader.Find(k_FillShaderName))
             {
                 hideFlags = HideFlags.HideAndDontSave,
             };
             m_PaintMaterial = new(Shader.Find(k_PaintShaderName))
+            {
+                hideFlags = HideFlags.HideAndDontSave,
+            };
+            m_TrianglePaintMaterial = new(Shader.Find(k_TrianglePaintShaderName))
             {
                 hideFlags = HideFlags.HideAndDontSave,
             };
@@ -156,8 +297,11 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 Handles.color = new(GUI.color.r * m_BrushColor.r, GUI.color.g * m_BrushColor.g, GUI.color.b * m_BrushColor.b, GUI.color.a * m_BrushColor.a);
                 Handles.DrawWireDisc(Vector3.zero, Vector3.forward, 0.5f);
 
-                Handles.color = new(GUI.color.r * m_BrushColor.r, GUI.color.g * m_BrushColor.g, GUI.color.b * m_BrushColor.b, GUI.color.a * m_BrushColor.a * m_BrushStrength);
-                Handles.DrawSolidDisc(Vector3.zero, Vector3.forward, 0.5f * m_BrushHardness);
+                if (m_BrushMode == BrushMode.Circle)
+                {
+                    Handles.color = new(GUI.color.r * m_BrushColor.r, GUI.color.g * m_BrushColor.g, GUI.color.b * m_BrushColor.b, GUI.color.a * m_BrushColor.a * m_BrushStrength);
+                    Handles.DrawSolidDisc(Vector3.zero, Vector3.forward, 0.5f * m_BrushHardness);
+                }
 
                 Handles.matrix = Matrix4x4.identity;
             }
@@ -174,6 +318,12 @@ namespace net.nekobako.MaskTextureEditor.Editor
             m_Buffer.width = texture.width;
             m_Buffer.height = texture.height;
             m_Buffer.Create();
+
+            m_TriangleMask.Release();
+            m_TriangleMask.width = texture.width;
+            m_TriangleMask.height = texture.height;
+            m_TriangleMask.Create();
+            m_TriangleLookup = null;
 
             Graphics.Blit(texture, m_Target);
             RenderTexture.active = null;
@@ -200,36 +350,203 @@ namespace net.nekobako.MaskTextureEditor.Editor
             RenderTexture.active = null;
         }
 
-        public void Paint(Vector2 position, bool stroke)
+        public void BeginStroke(Vector2 position, Vector2[]? points, int[]? indices)
         {
+            m_BrushPosition = position;
+            m_PaintedTriangles.Clear();
+            m_StrokeModified = false;
+
+            if (m_BrushMode == BrushMode.Triangle)
+            {
+                m_HitTriangles.Clear();
+                CollectHitTriangles(position, points, indices, m_HitTriangles);
+                PaintTriangles(points, indices, m_HitTriangles);
+            }
+            else
+            {
+                PaintCircle(position);
+            }
+        }
+
+        public void ContinueStroke(Vector2 position, Vector2[]? points, int[]? indices)
+        {
+            var delta = position - m_BrushPosition;
+            var spacing = m_BrushSize / m_BrushDensity;
+            var spacingSquared = spacing * spacing;
+            m_HitTriangles.Clear();
+            while (delta.sqrMagnitude >= spacingSquared)
+            {
+                m_BrushPosition += delta * (spacing / Mathf.Sqrt(delta.sqrMagnitude));
+                if (m_BrushMode == BrushMode.Triangle)
+                {
+                    CollectHitTriangles(m_BrushPosition, points, indices, m_HitTriangles);
+                }
+                else
+                {
+                    PaintCircle(m_BrushPosition);
+                }
+                delta = position - m_BrushPosition;
+            }
+
+            if (m_BrushMode == BrushMode.Triangle)
+            {
+                PaintTriangles(points, indices, m_HitTriangles);
+            }
+        }
+
+        public bool EndStroke()
+        {
+            return m_StrokeModified;
+        }
+
+        private void PaintCircle(Vector2 position)
+        {
+            if (m_BrushStrength <= 0.0f)
+            {
+                return;
+            }
+
             m_PaintMaterial.SetInt(s_ColorMaskPropertyId, (int)m_ColorMask);
             m_PaintMaterial.SetFloat(s_BrushSizePropertyId, m_BrushSize);
             m_PaintMaterial.SetFloat(s_BrushHardnessPropertyId, m_BrushHardness);
             m_PaintMaterial.SetFloat(s_BrushStrengthPropertyId, m_BrushStrength);
             m_PaintMaterial.SetColor(s_BrushColorPropertyId, m_BrushColor);
+            m_PaintMaterial.SetVector(s_BrushPositionPropertyId, new(position.x, TextureSize.y - position.y));
 
-            if (stroke)
-            {
-                var delta = position - m_BrushPosition;
-                for (var i = 0; i < Mathf.FloorToInt(delta.magnitude / (m_BrushSize / m_BrushDensity)); i++)
-                {
-                    m_BrushPosition += delta.normalized * (m_BrushSize / m_BrushDensity);
-                    m_PaintMaterial.SetVector(s_BrushPositionPropertyId, new(m_BrushPosition.x, TextureSize.y - m_BrushPosition.y));
-
-                    Graphics.Blit(m_Target, m_Buffer);
-                    Graphics.Blit(m_Buffer, m_Target, m_PaintMaterial);
-                }
-            }
-            else
-            {
-                m_BrushPosition = position;
-                m_PaintMaterial.SetVector(s_BrushPositionPropertyId, new(m_BrushPosition.x, TextureSize.y - m_BrushPosition.y));
-
-                Graphics.Blit(m_Target, m_Buffer);
-                Graphics.Blit(m_Buffer, m_Target, m_PaintMaterial);
-            }
-
+            Graphics.Blit(m_Target, m_Buffer);
+            Graphics.Blit(m_Buffer, m_Target, m_PaintMaterial);
             RenderTexture.active = null;
+            m_StrokeModified = true;
+        }
+
+        private void CollectHitTriangles(Vector2 position, Vector2[]? points, int[]? indices, List<int> hitTriangles)
+        {
+            if (m_BrushStrength <= 0.0f || points == null || indices == null)
+            {
+                return;
+            }
+
+            if (m_TriangleLookup == null ||
+                m_TriangleLookup.Points != points ||
+                m_TriangleLookup.Indices != indices ||
+                m_TriangleLookup.TextureSize != TextureSize)
+            {
+                m_TriangleLookup = new(points, indices, TextureSize);
+            }
+
+            var radius = m_BrushSize * 0.5f;
+            m_TriangleLookup.CollectCandidates(position, radius, TextureSize, m_TriangleCandidates);
+            foreach (var offset in m_TriangleCandidates)
+            {
+                var triangle = offset / 3;
+                if (m_PaintedTriangles.Contains(triangle))
+                {
+                    continue;
+                }
+
+                var a = m_TriangleLookup.PixelPoints[indices[offset]];
+                var b = m_TriangleLookup.PixelPoints[indices[offset + 1]];
+                var c = m_TriangleLookup.PixelPoints[indices[offset + 2]];
+                if (!CircleIntersectsTriangle(position, radius, a, b, c))
+                {
+                    continue;
+                }
+
+                m_PaintedTriangles.Add(triangle);
+                hitTriangles.Add(offset);
+            }
+        }
+
+        private void PaintTriangles(Vector2[]? points, int[]? indices, List<int> hitTriangles)
+        {
+            if (points == null || indices == null || hitTriangles.Count == 0)
+            {
+                return;
+            }
+
+            m_TrianglePaintMaterial.SetInt(s_ColorMaskPropertyId, (int)m_ColorMask);
+            m_TrianglePaintMaterial.SetColor(s_BrushColorPropertyId, m_BrushColor);
+            m_TrianglePaintMaterial.SetFloat(s_BrushStrengthPropertyId, m_BrushStrength);
+            m_TrianglePaintMaterial.SetTexture(s_TriangleMaskPropertyId, m_TriangleMask);
+
+            var previous = RenderTexture.active;
+            RenderTexture.active = m_TriangleMask;
+            GL.Clear(false, true, Color.clear);
+            GL.PushMatrix();
+            GL.LoadOrtho();
+            m_TrianglePaintMaterial.SetPass(0);
+            GL.Begin(GL.TRIANGLES);
+            foreach (var offset in hitTriangles)
+            {
+                GL.Vertex3(points[indices[offset]].x, points[indices[offset]].y, 0.0f);
+                GL.Vertex3(points[indices[offset + 1]].x, points[indices[offset + 1]].y, 0.0f);
+                GL.Vertex3(points[indices[offset + 2]].x, points[indices[offset + 2]].y, 0.0f);
+            }
+            GL.End();
+            GL.PopMatrix();
+
+            Graphics.Blit(m_Target, m_Buffer);
+            Graphics.Blit(m_Buffer, m_Target, m_TrianglePaintMaterial, 1);
+            RenderTexture.active = previous;
+            m_StrokeModified = true;
+        }
+
+        private static bool CircleIntersectsTriangle(Vector2 center, float radius, Vector2 a, Vector2 b, Vector2 c)
+        {
+            var min = Vector2.Min(a, Vector2.Min(b, c));
+            var max = Vector2.Max(a, Vector2.Max(b, c));
+            if (center.x + radius < min.x || center.x - radius > max.x ||
+                center.y + radius < min.y || center.y - radius > max.y)
+            {
+                return false;
+            }
+
+            if (Mathf.Abs(Cross(b - a, c - a)) < Mathf.Epsilon)
+            {
+                return false;
+            }
+
+            if (PointInTriangle(center, a, b, c))
+            {
+                return true;
+            }
+
+            var radiusSquared = radius * radius;
+            return
+                (a - center).sqrMagnitude <= radiusSquared ||
+                (b - center).sqrMagnitude <= radiusSquared ||
+                (c - center).sqrMagnitude <= radiusSquared ||
+                DistanceToSegmentSquared(center, a, b) <= radiusSquared ||
+                DistanceToSegmentSquared(center, b, c) <= radiusSquared ||
+                DistanceToSegmentSquared(center, c, a) <= radiusSquared;
+        }
+
+        private static bool PointInTriangle(Vector2 point, Vector2 a, Vector2 b, Vector2 c)
+        {
+            var ab = Cross(b - a, point - a);
+            var bc = Cross(c - b, point - b);
+            var ca = Cross(a - c, point - c);
+            return
+                (ab >= 0.0f && bc >= 0.0f && ca >= 0.0f) ||
+                (ab <= 0.0f && bc <= 0.0f && ca <= 0.0f);
+        }
+
+        private static float DistanceToSegmentSquared(Vector2 point, Vector2 a, Vector2 b)
+        {
+            var segment = b - a;
+            var lengthSquared = segment.sqrMagnitude;
+            if (lengthSquared <= Mathf.Epsilon)
+            {
+                return (point - a).sqrMagnitude;
+            }
+
+            var t = Mathf.Clamp01(Vector2.Dot(point - a, segment) / lengthSquared);
+            return (point - (a + segment * t)).sqrMagnitude;
+        }
+
+        private static float Cross(Vector2 a, Vector2 b)
+        {
+            return a.x * b.y - a.y * b.x;
         }
 
         public void Inverse()
@@ -253,6 +570,11 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 DestroyImmediate(m_Buffer);
                 m_Buffer = null!; // Reset
             }
+            if (m_TriangleMask != null)
+            {
+                DestroyImmediate(m_TriangleMask);
+                m_TriangleMask = null!; // Reset
+            }
             if (m_FillMaterial != null)
             {
                 DestroyImmediate(m_FillMaterial);
@@ -262,6 +584,11 @@ namespace net.nekobako.MaskTextureEditor.Editor
             {
                 DestroyImmediate(m_PaintMaterial);
                 m_PaintMaterial = null!; // Reset
+            }
+            if (m_TrianglePaintMaterial != null)
+            {
+                DestroyImmediate(m_TrianglePaintMaterial);
+                m_TrianglePaintMaterial = null!; // Reset
             }
             if (m_InverseMaterial != null)
             {

--- a/Packages/net.nekobako.mask-texture-editor/Editor/TexturePainter.cs
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/TexturePainter.cs
@@ -11,6 +11,13 @@ namespace net.nekobako.MaskTextureEditor.Editor
         Triangle,
     }
 
+    internal enum GradientShape
+    {
+        Line,
+        Band,
+        Radial,
+    }
+
     internal class TexturePainter : ScriptableObject
     {
         private sealed class TriangleLookup
@@ -118,6 +125,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
         private const string k_FillShaderName = "Hidden/MaskTextureEditor/Fill";
         private const string k_PaintShaderName = "Hidden/MaskTextureEditor/Paint";
         private const string k_TrianglePaintShaderName = "Hidden/MaskTextureEditor/TrianglePaint";
+        private const string k_GradientShaderName = "Hidden/MaskTextureEditor/Gradient";
         private const string k_InverseShaderName = "Hidden/MaskTextureEditor/Inverse";
 
         private static readonly int s_ColorMaskPropertyId = Shader.PropertyToID("_ColorMask");
@@ -128,6 +136,17 @@ namespace net.nekobako.MaskTextureEditor.Editor
         private static readonly int s_BrushColorPropertyId = Shader.PropertyToID("_BrushColor");
         private static readonly int s_BrushPositionPropertyId = Shader.PropertyToID("_BrushPosition");
         private static readonly int s_TriangleMaskPropertyId = Shader.PropertyToID("_TriangleMask");
+        private static readonly int s_SelectionMaskPropertyId = Shader.PropertyToID("_SelectionMask");
+        private static readonly int s_UseSelectionMaskPropertyId = Shader.PropertyToID("_UseSelectionMask");
+        private static readonly int s_StartPointPropertyId = Shader.PropertyToID("_StartPoint");
+        private static readonly int s_EndPointPropertyId = Shader.PropertyToID("_EndPoint");
+        private static readonly int s_StartValuePropertyId = Shader.PropertyToID("_StartValue");
+        private static readonly int s_EndValuePropertyId = Shader.PropertyToID("_EndValue");
+        private static readonly int s_CurveExponentPropertyId = Shader.PropertyToID("_CurveExponent");
+        private static readonly int s_TextureSizePropertyId = Shader.PropertyToID("_TextureSize");
+        private static readonly int s_GradientShapePropertyId = Shader.PropertyToID("_GradientShape");
+        private static readonly int s_GradientWidthPropertyId = Shader.PropertyToID("_GradientWidth");
+        private static readonly int s_GradientFeatherPropertyId = Shader.PropertyToID("_GradientFeather");
 
         [SerializeField]
         private RenderTexture m_Target = null!; // Initialize in Init
@@ -139,6 +158,12 @@ namespace net.nekobako.MaskTextureEditor.Editor
         private RenderTexture m_TriangleMask = null!; // Initialize in Init
 
         [SerializeField]
+        private RenderTexture m_GradientSource = null!; // Initialize in Init
+
+        [SerializeField]
+        private RenderTexture m_GradientPreview = null!; // Initialize in Init
+
+        [SerializeField]
         private Material m_FillMaterial = null!; // Initialize in Init
 
         [SerializeField]
@@ -146,6 +171,9 @@ namespace net.nekobako.MaskTextureEditor.Editor
 
         [SerializeField]
         private Material m_TrianglePaintMaterial = null!; // Initialize in Init
+
+        [SerializeField]
+        private Material m_GradientMaterial = null!; // Initialize in Init
 
         [SerializeField]
         private Material m_InverseMaterial = null!; // Initialize in Init
@@ -177,9 +205,11 @@ namespace net.nekobako.MaskTextureEditor.Editor
         private readonly List<int> m_HitTriangles = new();
         private TriangleLookup? m_TriangleLookup = null;
         private bool m_StrokeModified = false;
+        private bool m_IsGradientPreview = false;
 
         public RenderTexture Texture => m_Target;
         public Vector2 TextureSize => new(m_Target.width, m_Target.height);
+        public bool IsGradientPreview => m_IsGradientPreview;
 
         public BrushMode BrushMode
         {
@@ -258,6 +288,14 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 filterMode = FilterMode.Point,
                 wrapMode = TextureWrapMode.Clamp,
             };
+            m_GradientSource = new(size.x, size.y, 0)
+            {
+                hideFlags = HideFlags.HideAndDontSave,
+            };
+            m_GradientPreview = new(size.x, size.y, 0)
+            {
+                hideFlags = HideFlags.HideAndDontSave,
+            };
             m_FillMaterial = new(Shader.Find(k_FillShaderName))
             {
                 hideFlags = HideFlags.HideAndDontSave,
@@ -267,6 +305,10 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 hideFlags = HideFlags.HideAndDontSave,
             };
             m_TrianglePaintMaterial = new(Shader.Find(k_TrianglePaintShaderName))
+            {
+                hideFlags = HideFlags.HideAndDontSave,
+            };
+            m_GradientMaterial = new(Shader.Find(k_GradientShaderName))
             {
                 hideFlags = HideFlags.HideAndDontSave,
             };
@@ -284,7 +326,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
             color.g = (m_ColorMask & ColorWriteMask.Green) != 0 ? color.g : 0.0f;
             color.b = (m_ColorMask & ColorWriteMask.Blue) != 0 ? color.b : 0.0f;
             GUI.color = color;
-            GUI.DrawTexture(rect, m_Target);
+            GUI.DrawTexture(rect, m_IsGradientPreview ? m_GradientPreview : m_Target);
 
             // Draw the brush
             if (brush)
@@ -325,6 +367,10 @@ namespace net.nekobako.MaskTextureEditor.Editor
             m_TriangleMask.Create();
             m_TriangleLookup = null;
 
+            ResizeRenderTexture(m_GradientSource, texture.width, texture.height);
+            ResizeRenderTexture(m_GradientPreview, texture.width, texture.height);
+            m_IsGradientPreview = false;
+
             Graphics.Blit(texture, m_Target);
             RenderTexture.active = null;
         }
@@ -340,17 +386,18 @@ namespace net.nekobako.MaskTextureEditor.Editor
             RenderTexture.active = null;
         }
 
-        public void Fill(Color color)
+        public void Fill(Color color, Texture? selectionMask = null)
         {
             m_FillMaterial.SetInt(s_ColorMaskPropertyId, (int)m_ColorMask);
             m_FillMaterial.SetColor(s_ColorPropertyId, color);
+            SetSelectionMask(m_FillMaterial, selectionMask);
 
             Graphics.Blit(m_Target, m_Buffer);
             Graphics.Blit(m_Buffer, m_Target, m_FillMaterial);
             RenderTexture.active = null;
         }
 
-        public void BeginStroke(Vector2 position, Vector2[]? points, int[]? indices)
+        public void BeginStroke(Vector2 position, Vector2[]? points, int[]? indices, Texture? selectionMask)
         {
             m_BrushPosition = position;
             m_PaintedTriangles.Clear();
@@ -360,15 +407,15 @@ namespace net.nekobako.MaskTextureEditor.Editor
             {
                 m_HitTriangles.Clear();
                 CollectHitTriangles(position, points, indices, m_HitTriangles);
-                PaintTriangles(points, indices, m_HitTriangles);
+                PaintTriangles(points, indices, m_HitTriangles, selectionMask);
             }
             else
             {
-                PaintCircle(position);
+                PaintCircle(position, selectionMask);
             }
         }
 
-        public void ContinueStroke(Vector2 position, Vector2[]? points, int[]? indices)
+        public void ContinueStroke(Vector2 position, Vector2[]? points, int[]? indices, Texture? selectionMask)
         {
             var delta = position - m_BrushPosition;
             var spacing = m_BrushSize / m_BrushDensity;
@@ -383,14 +430,14 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 }
                 else
                 {
-                    PaintCircle(m_BrushPosition);
+                    PaintCircle(m_BrushPosition, selectionMask);
                 }
                 delta = position - m_BrushPosition;
             }
 
             if (m_BrushMode == BrushMode.Triangle)
             {
-                PaintTriangles(points, indices, m_HitTriangles);
+                PaintTriangles(points, indices, m_HitTriangles, selectionMask);
             }
         }
 
@@ -399,7 +446,72 @@ namespace net.nekobako.MaskTextureEditor.Editor
             return m_StrokeModified;
         }
 
-        private void PaintCircle(Vector2 position)
+        public void BeginGradient()
+        {
+            Graphics.Blit(m_Target, m_GradientSource);
+            Graphics.Blit(m_Target, m_GradientPreview);
+            RenderTexture.active = null;
+            m_IsGradientPreview = true;
+        }
+
+        public bool UpdateGradient(
+            Vector2 start,
+            Vector2 end,
+            float startValue,
+            float endValue,
+            float curveExponent,
+            GradientShape shape,
+            float width,
+            float feather,
+            Texture? selectionMask)
+        {
+            if (!m_IsGradientPreview)
+            {
+                return false;
+            }
+
+            if ((end - start).sqrMagnitude <= Mathf.Epsilon)
+            {
+                Graphics.Blit(m_GradientSource, m_GradientPreview);
+                RenderTexture.active = null;
+                return false;
+            }
+
+            m_GradientMaterial.SetInt(s_ColorMaskPropertyId, (int)m_ColorMask);
+            SetSelectionMask(m_GradientMaterial, selectionMask);
+            m_GradientMaterial.SetVector(s_StartPointPropertyId, start);
+            m_GradientMaterial.SetVector(s_EndPointPropertyId, end);
+            m_GradientMaterial.SetFloat(s_StartValuePropertyId, startValue);
+            m_GradientMaterial.SetFloat(s_EndValuePropertyId, endValue);
+            m_GradientMaterial.SetFloat(s_CurveExponentPropertyId, curveExponent);
+            m_GradientMaterial.SetVector(s_TextureSizePropertyId, new(TextureSize.x, TextureSize.y, 0.0f, 0.0f));
+            m_GradientMaterial.SetInt(s_GradientShapePropertyId, (int)shape);
+            m_GradientMaterial.SetFloat(s_GradientWidthPropertyId, width);
+            m_GradientMaterial.SetFloat(s_GradientFeatherPropertyId, feather);
+            Graphics.Blit(m_GradientSource, m_GradientPreview, m_GradientMaterial);
+            RenderTexture.active = null;
+            return true;
+        }
+
+        public bool CommitGradient()
+        {
+            if (!m_IsGradientPreview)
+            {
+                return false;
+            }
+
+            Graphics.Blit(m_GradientPreview, m_Target);
+            RenderTexture.active = null;
+            m_IsGradientPreview = false;
+            return true;
+        }
+
+        public void CancelGradient()
+        {
+            m_IsGradientPreview = false;
+        }
+
+        private void PaintCircle(Vector2 position, Texture? selectionMask)
         {
             if (m_BrushStrength <= 0.0f)
             {
@@ -412,6 +524,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
             m_PaintMaterial.SetFloat(s_BrushStrengthPropertyId, m_BrushStrength);
             m_PaintMaterial.SetColor(s_BrushColorPropertyId, m_BrushColor);
             m_PaintMaterial.SetVector(s_BrushPositionPropertyId, new(position.x, TextureSize.y - position.y));
+            SetSelectionMask(m_PaintMaterial, selectionMask);
 
             Graphics.Blit(m_Target, m_Buffer);
             Graphics.Blit(m_Buffer, m_Target, m_PaintMaterial);
@@ -457,7 +570,11 @@ namespace net.nekobako.MaskTextureEditor.Editor
             }
         }
 
-        private void PaintTriangles(Vector2[]? points, int[]? indices, List<int> hitTriangles)
+        private void PaintTriangles(
+            Vector2[]? points,
+            int[]? indices,
+            List<int> hitTriangles,
+            Texture? selectionMask)
         {
             if (points == null || indices == null || hitTriangles.Count == 0)
             {
@@ -468,6 +585,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
             m_TrianglePaintMaterial.SetColor(s_BrushColorPropertyId, m_BrushColor);
             m_TrianglePaintMaterial.SetFloat(s_BrushStrengthPropertyId, m_BrushStrength);
             m_TrianglePaintMaterial.SetTexture(s_TriangleMaskPropertyId, m_TriangleMask);
+            SetSelectionMask(m_TrianglePaintMaterial, selectionMask);
 
             var previous = RenderTexture.active;
             RenderTexture.active = m_TriangleMask;
@@ -549,9 +667,24 @@ namespace net.nekobako.MaskTextureEditor.Editor
             return a.x * b.y - a.y * b.x;
         }
 
-        public void Inverse()
+        private static void ResizeRenderTexture(RenderTexture texture, int width, int height)
+        {
+            texture.Release();
+            texture.width = width;
+            texture.height = height;
+            texture.Create();
+        }
+
+        private static void SetSelectionMask(Material material, Texture? selectionMask)
+        {
+            material.SetTexture(s_SelectionMaskPropertyId, selectionMask);
+            material.SetFloat(s_UseSelectionMaskPropertyId, selectionMask != null ? 1.0f : 0.0f);
+        }
+
+        public void Inverse(Texture? selectionMask = null)
         {
             m_InverseMaterial.SetInt(s_ColorMaskPropertyId, (int)m_ColorMask);
+            SetSelectionMask(m_InverseMaterial, selectionMask);
 
             Graphics.Blit(m_Target, m_Buffer);
             Graphics.Blit(m_Buffer, m_Target, m_InverseMaterial);
@@ -575,6 +708,16 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 DestroyImmediate(m_TriangleMask);
                 m_TriangleMask = null!; // Reset
             }
+            if (m_GradientSource != null)
+            {
+                DestroyImmediate(m_GradientSource);
+                m_GradientSource = null!; // Reset
+            }
+            if (m_GradientPreview != null)
+            {
+                DestroyImmediate(m_GradientPreview);
+                m_GradientPreview = null!; // Reset
+            }
             if (m_FillMaterial != null)
             {
                 DestroyImmediate(m_FillMaterial);
@@ -589,6 +732,11 @@ namespace net.nekobako.MaskTextureEditor.Editor
             {
                 DestroyImmediate(m_TrianglePaintMaterial);
                 m_TrianglePaintMaterial = null!; // Reset
+            }
+            if (m_GradientMaterial != null)
+            {
+                DestroyImmediate(m_GradientMaterial);
+                m_GradientMaterial = null!; // Reset
             }
             if (m_InverseMaterial != null)
             {

--- a/Packages/net.nekobako.mask-texture-editor/Editor/TexturePainter.cs
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/TexturePainter.cs
@@ -127,6 +127,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
         private const string k_TrianglePaintShaderName = "Hidden/MaskTextureEditor/TrianglePaint";
         private const string k_GradientShaderName = "Hidden/MaskTextureEditor/Gradient";
         private const string k_InverseShaderName = "Hidden/MaskTextureEditor/Inverse";
+        private const float k_TriangleMaskPadding = 0.75f;
 
         private static readonly int s_ColorMaskPropertyId = Shader.PropertyToID("_ColorMask");
         private static readonly int s_ColorPropertyId = Shader.PropertyToID("_Color");
@@ -596,9 +597,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
             GL.Begin(GL.TRIANGLES);
             foreach (var offset in hitTriangles)
             {
-                GL.Vertex3(points[indices[offset]].x, points[indices[offset]].y, 0.0f);
-                GL.Vertex3(points[indices[offset + 1]].x, points[indices[offset + 1]].y, 0.0f);
-                GL.Vertex3(points[indices[offset + 2]].x, points[indices[offset + 2]].y, 0.0f);
+                EmitPaddedUvTriangle(points, indices, offset, TextureSize, k_TriangleMaskPadding);
             }
             GL.End();
             GL.PopMatrix();
@@ -665,6 +664,50 @@ namespace net.nekobako.MaskTextureEditor.Editor
         private static float Cross(Vector2 a, Vector2 b)
         {
             return a.x * b.y - a.y * b.x;
+        }
+
+        internal static void EmitPaddedUvTriangle(
+            Vector2[] points,
+            int[] indices,
+            int offset,
+            Vector2 textureSize,
+            float padding)
+        {
+            var a = points[indices[offset]];
+            var b = points[indices[offset + 1]];
+            var c = points[indices[offset + 2]];
+
+            if (padding > 0.0f && textureSize.x > 0.0f && textureSize.y > 0.0f)
+            {
+                var pixelScale = new Vector2(textureSize.x, textureSize.y);
+                var pixelA = Vector2.Scale(a, pixelScale);
+                var pixelB = Vector2.Scale(b, pixelScale);
+                var pixelC = Vector2.Scale(c, pixelScale);
+                var center = (pixelA + pixelB + pixelC) / 3.0f;
+
+                pixelA = PadTriangleVertex(pixelA, center, padding);
+                pixelB = PadTriangleVertex(pixelB, center, padding);
+                pixelC = PadTriangleVertex(pixelC, center, padding);
+
+                a = new(pixelA.x / textureSize.x, pixelA.y / textureSize.y);
+                b = new(pixelB.x / textureSize.x, pixelB.y / textureSize.y);
+                c = new(pixelC.x / textureSize.x, pixelC.y / textureSize.y);
+            }
+
+            GL.Vertex3(a.x, a.y, 0.0f);
+            GL.Vertex3(b.x, b.y, 0.0f);
+            GL.Vertex3(c.x, c.y, 0.0f);
+        }
+
+        private static Vector2 PadTriangleVertex(Vector2 vertex, Vector2 center, float padding)
+        {
+            var direction = vertex - center;
+            if (direction.sqrMagnitude <= Mathf.Epsilon)
+            {
+                return vertex;
+            }
+
+            return vertex + direction.normalized * padding;
         }
 
         private static void ResizeRenderTexture(RenderTexture texture, int width, int height)

--- a/Packages/net.nekobako.mask-texture-editor/Editor/TextureUndoStack.cs
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/TextureUndoStack.cs
@@ -89,7 +89,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
 
             if (m_Counter.Count > 0)
             {
-                UnityEditor.Undo.RecordObject(m_Counter, "Modify Texture");
+                UnityEditor.Undo.RegisterCompleteObjectUndo(m_Counter, "Modify Texture");
             }
             m_Counter.Count++;
         }
@@ -98,7 +98,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
         {
             if (CanUndo)
             {
-                UnityEditor.Undo.RecordObject(m_Counter, "Undo Texture");
+                UnityEditor.Undo.RegisterCompleteObjectUndo(m_Counter, "Undo Texture");
                 m_Counter.Count--;
 
                 Apply();
@@ -109,7 +109,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
         {
             if (CanRedo)
             {
-                UnityEditor.Undo.RecordObject(m_Counter, "Redo Texture");
+                UnityEditor.Undo.RegisterCompleteObjectUndo(m_Counter, "Redo Texture");
                 m_Counter.Count++;
 
                 Apply();
@@ -132,6 +132,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
         {
             Graphics.Blit(Peek(), m_Target);
             RenderTexture.active = null;
+            Window.RepaintIfOpen();
         }
 
         private void OnDestroy()

--- a/Packages/net.nekobako.mask-texture-editor/Editor/UvMapDrawer.cs
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/UvMapDrawer.cs
@@ -7,6 +7,8 @@ namespace net.nekobako.MaskTextureEditor.Editor
     internal class UvMapDrawer : ScriptableObject
     {
         private const string k_NormalOverlayShaderName = "Hidden/MaskTextureEditor/NormalOverlay";
+        private const string k_SelectionMaskShaderName = "Hidden/MaskTextureEditor/SelectionOverlay";
+        private const float k_SelectionOverlayOpacity = 0.4f;
 
         [SerializeField]
         private Renderer? m_Renderer = null;
@@ -43,11 +45,13 @@ namespace net.nekobako.MaskTextureEditor.Editor
         private bool m_IsDirty = false;
         private Mesh? m_Mesh = null;
         private int m_MeshDirtyCount = 0;
-        private Vector2[]? m_Points = null;
+        private MeshUvData? m_Data = null;
         private Vector3[]? m_Buffer = null;
-        private int[]? m_LineIndices = null;
-        private int[]? m_TriangleIndices = null;
-        private Color[]? m_NormalColors = null;
+
+        [SerializeField]
+        private int m_ActiveIsland = -1;
+
+        public bool HasActiveIsland => m_ActiveIsland >= 0;
 
         [SerializeField]
         private RenderTexture m_NormalOverlay = null!;
@@ -55,11 +59,18 @@ namespace net.nekobako.MaskTextureEditor.Editor
         [SerializeField]
         private Material m_NormalOverlayMaterial = null!;
 
+        [SerializeField]
+        private RenderTexture m_SelectionMask = null!;
+
+        [SerializeField]
+        private Material m_SelectionMaskMaterial = null!;
+
         private void Awake()
         {
             // Set HideFlags to keep the state when reloading a scene or domain
             hideFlags = HideFlags.HideAndDontSave;
             EnsureNormalOverlayMaterial();
+            EnsureSelectionMaskMaterial();
         }
 
         public void Init(Renderer? renderer, int? slot)
@@ -68,7 +79,13 @@ namespace net.nekobako.MaskTextureEditor.Editor
             m_Slot = slot ?? 0;
         }
 
-        public void Draw(Rect rect, Vector2Int textureSize, bool showUvWireframe, bool showNormalOverlay, float normalOverlayOpacity)
+        public void Draw(
+            Rect rect,
+            Vector2Int textureSize,
+            bool showUvWireframe,
+            bool showNormalOverlay,
+            float normalOverlayOpacity,
+            bool showSelectionOverlay)
         {
             var (mesh, material) = CollectMeshAndMaterial();
             if (m_IsDirty ||
@@ -78,9 +95,11 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 m_IsDirty = false;
                 m_Mesh = mesh;
                 m_MeshDirtyCount = EditorUtility.GetDirtyCount(m_Mesh);
-                (m_Points, m_LineIndices, m_TriangleIndices, m_NormalColors) = CollectMeshData();
-                m_Buffer = m_Points != null ? new Vector3[m_Points.Length] : null;
+                m_Data = CollectMeshData();
+                m_Buffer = m_Data != null ? new Vector3[m_Data.Points.Length] : null;
+                m_ActiveIsland = -1;
                 ReleaseNormalOverlay();
+                ReleaseSelectionMask();
             }
 
             if (material != null && material.mainTexture != null)
@@ -97,15 +116,23 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 GUI.color = color;
             }
 
-            if (showUvWireframe && m_Points != null && m_Buffer != null && m_LineIndices != null)
+            if (showSelectionOverlay && TryGetSelectionMask(textureSize, out var selectionMask))
+            {
+                var color = GUI.color;
+                GUI.color = new(0.0f, 0.75f, 1.0f, color.a * k_SelectionOverlayOpacity);
+                GUI.DrawTexture(rect, selectionMask, ScaleMode.StretchToFill, true);
+                GUI.color = color;
+            }
+
+            if (showUvWireframe && m_Data != null && m_Buffer != null)
             {
                 // Draw line shadows for visibility
                 for (var i = 0; i < m_Buffer.Length; i++)
                 {
-                    m_Buffer[i] = Rect.NormalizedToPoint(rect, new(m_Points[i].x, 1.0f - m_Points[i].y));
+                    m_Buffer[i] = Rect.NormalizedToPoint(rect, new(m_Data.Points[i].x, 1.0f - m_Data.Points[i].y));
                 }
                 Handles.color = GUI.color * Color.black;
-                Handles.DrawLines(m_Buffer, m_LineIndices);
+                Handles.DrawLines(m_Buffer, m_Data.LineIndices);
 
                 // Draw lines with offset
                 for (var i = 0; i < m_Buffer.Length; i++)
@@ -113,15 +140,14 @@ namespace net.nekobako.MaskTextureEditor.Editor
                     m_Buffer[i] -= Vector3.one;
                 }
                 Handles.color = GUI.color * Color.white;
-                Handles.DrawLines(m_Buffer, m_LineIndices);
+                Handles.DrawLines(m_Buffer, m_Data.LineIndices);
             }
         }
 
         private bool TryRenderNormalOverlay(Vector2Int textureSize)
         {
-            if (m_Points == null ||
-                m_TriangleIndices == null ||
-                m_NormalColors == null ||
+            if (m_Data?.TriangleIndices == null ||
+                m_Data.NormalColors == null ||
                 textureSize.x <= 0 ||
                 textureSize.y <= 0)
             {
@@ -152,14 +178,14 @@ namespace net.nekobako.MaskTextureEditor.Editor
             GL.LoadOrtho();
             m_NormalOverlayMaterial.SetPass(0);
             GL.Begin(GL.TRIANGLES);
-            for (var offset = 0; offset + 2 < m_TriangleIndices.Length; offset += 3)
+            for (var offset = 0; offset + 2 < m_Data.TriangleIndices.Length; offset += 3)
             {
-                GL.Color(m_NormalColors[offset]);
-                GL.Vertex3(m_Points[m_TriangleIndices[offset]].x, m_Points[m_TriangleIndices[offset]].y, 0.0f);
-                GL.Color(m_NormalColors[offset + 1]);
-                GL.Vertex3(m_Points[m_TriangleIndices[offset + 1]].x, m_Points[m_TriangleIndices[offset + 1]].y, 0.0f);
-                GL.Color(m_NormalColors[offset + 2]);
-                GL.Vertex3(m_Points[m_TriangleIndices[offset + 2]].x, m_Points[m_TriangleIndices[offset + 2]].y, 0.0f);
+                GL.Color(m_Data.NormalColors[offset]);
+                GL.Vertex3(m_Data.Points[m_Data.TriangleIndices[offset]].x, m_Data.Points[m_Data.TriangleIndices[offset]].y, 0.0f);
+                GL.Color(m_Data.NormalColors[offset + 1]);
+                GL.Vertex3(m_Data.Points[m_Data.TriangleIndices[offset + 1]].x, m_Data.Points[m_Data.TriangleIndices[offset + 1]].y, 0.0f);
+                GL.Color(m_Data.NormalColors[offset + 2]);
+                GL.Vertex3(m_Data.Points[m_Data.TriangleIndices[offset + 2]].x, m_Data.Points[m_Data.TriangleIndices[offset + 2]].y, 0.0f);
             }
             GL.End();
             GL.PopMatrix();
@@ -180,17 +206,129 @@ namespace net.nekobako.MaskTextureEditor.Editor
             };
         }
 
+        public bool TryGetSelectionMask(Vector2Int textureSize, out RenderTexture selectionMask)
+        {
+            if (m_ActiveIsland < 0 ||
+                m_Data?.TriangleIndices == null ||
+                m_Data.Topology == null ||
+                textureSize.x <= 0 ||
+                textureSize.y <= 0)
+            {
+                selectionMask = null!;
+                return false;
+            }
+
+            if (m_SelectionMask != null &&
+                m_SelectionMask.width == textureSize.x &&
+                m_SelectionMask.height == textureSize.y)
+            {
+                selectionMask = m_SelectionMask;
+                return true;
+            }
+
+            ReleaseSelectionMask();
+            EnsureSelectionMaskMaterial();
+            m_SelectionMask = new(textureSize.x, textureSize.y, 0, RenderTextureFormat.ARGB32)
+            {
+                hideFlags = HideFlags.HideAndDontSave,
+                filterMode = FilterMode.Point,
+                wrapMode = TextureWrapMode.Clamp,
+            };
+            m_SelectionMask.Create();
+
+            var previous = RenderTexture.active;
+            RenderTexture.active = m_SelectionMask;
+            GL.Clear(false, true, Color.clear);
+            GL.PushMatrix();
+            GL.LoadOrtho();
+            m_SelectionMaskMaterial.SetPass(0);
+            GL.Begin(GL.TRIANGLES);
+            foreach (var triangle in m_Data.Topology.GetIslandTriangles(m_ActiveIsland))
+            {
+                var offset = triangle * 3;
+                GL.Vertex3(m_Data.Points[m_Data.TriangleIndices[offset]].x, m_Data.Points[m_Data.TriangleIndices[offset]].y, 0.0f);
+                GL.Vertex3(m_Data.Points[m_Data.TriangleIndices[offset + 1]].x, m_Data.Points[m_Data.TriangleIndices[offset + 1]].y, 0.0f);
+                GL.Vertex3(m_Data.Points[m_Data.TriangleIndices[offset + 2]].x, m_Data.Points[m_Data.TriangleIndices[offset + 2]].y, 0.0f);
+            }
+            GL.End();
+            GL.PopMatrix();
+            RenderTexture.active = previous;
+            selectionMask = m_SelectionMask;
+            return true;
+        }
+
+        private void EnsureSelectionMaskMaterial()
+        {
+            if (m_SelectionMaskMaterial != null)
+            {
+                return;
+            }
+
+            m_SelectionMaskMaterial = new(Shader.Find(k_SelectionMaskShaderName))
+            {
+                hideFlags = HideFlags.HideAndDontSave,
+            };
+        }
+
         public bool TryGetTriangles(out Vector2[] points, out int[] indices)
         {
-            if (m_Points != null && m_TriangleIndices != null)
+            if (m_Data?.TriangleIndices != null)
             {
-                points = m_Points;
-                indices = m_TriangleIndices;
+                points = m_Data.Points;
+                indices = m_Data.TriangleIndices;
                 return true;
             }
 
             points = null!;
             indices = null!;
+            return false;
+        }
+
+        public bool TryFindIsland(Vector2 point, out int island)
+        {
+            if (m_Data?.Topology != null && m_Data.Topology.TryFindIsland(point, out island))
+            {
+                return true;
+            }
+
+            island = -1;
+            return false;
+        }
+
+        public bool SetActiveIsland(int island)
+        {
+            if (m_ActiveIsland == island)
+            {
+                return false;
+            }
+
+            m_ActiveIsland = island;
+            ReleaseSelectionMask();
+            return true;
+        }
+
+        public void ClearActiveIsland()
+        {
+            if (m_ActiveIsland < 0)
+            {
+                return;
+            }
+
+            m_ActiveIsland = -1;
+            ReleaseSelectionMask();
+        }
+
+        public bool TryGetActiveIsland(out MeshUvData data, out IReadOnlyList<int> triangles)
+        {
+            if (m_ActiveIsland >= 0 && m_Data?.Topology != null)
+            {
+                data = m_Data;
+                triangles = m_Data.Topology.GetIslandTriangles(m_ActiveIsland);
+                return true;
+            }
+
+            data = null!;
+            triangles = null!;
             return false;
         }
 
@@ -226,16 +364,16 @@ namespace net.nekobako.MaskTextureEditor.Editor
             }
         }
 
-        private (Vector2[]?, int[]?, int[]?, Color[]?) CollectMeshData()
+        private MeshUvData? CollectMeshData()
         {
             if (m_Mesh == null)
             {
-                return (null, null, null, null);
+                return null;
             }
 
             if (m_Mesh.subMeshCount == 0)
             {
-                return (null, null, null, null);
+                return null;
             }
 
             var subMesh = Mathf.Clamp(m_Slot, 0, m_Mesh.subMeshCount - 1);
@@ -249,7 +387,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
             };
             if (topology == 0)
             {
-                return (null, null, null, null);
+                return null;
             }
 
             var lines = new HashSet<(int, int)>();
@@ -270,7 +408,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
 
             if (meshTopology != MeshTopology.Triangles)
             {
-                return (m_Mesh.uv, lineIndices.ToArray(), null, null);
+                return new(m_Mesh.uv, lineIndices.ToArray(), null, null);
             }
 
             var vertices = m_Mesh.vertices;
@@ -303,7 +441,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 }
             }
 
-            return (m_Mesh.uv, lineIndices.ToArray(), indices, normalColors);
+            return new(m_Mesh.uv, lineIndices.ToArray(), indices, normalColors);
         }
 
         private static Color EncodeNormal(Vector3 normal)
@@ -327,14 +465,31 @@ namespace net.nekobako.MaskTextureEditor.Editor
             m_NormalOverlay = null!;
         }
 
+        private void ReleaseSelectionMask()
+        {
+            if (m_SelectionMask == null)
+            {
+                return;
+            }
+
+            DestroyImmediate(m_SelectionMask);
+            m_SelectionMask = null!;
+        }
+
         private void OnDestroy()
         {
             ReleaseNormalOverlay();
+            ReleaseSelectionMask();
 
             if (m_NormalOverlayMaterial != null)
             {
                 DestroyImmediate(m_NormalOverlayMaterial);
                 m_NormalOverlayMaterial = null!;
+            }
+            if (m_SelectionMaskMaterial != null)
+            {
+                DestroyImmediate(m_SelectionMaskMaterial);
+                m_SelectionMaskMaterial = null!;
             }
         }
     }

--- a/Packages/net.nekobako.mask-texture-editor/Editor/UvMapDrawer.cs
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/UvMapDrawer.cs
@@ -6,6 +6,8 @@ namespace net.nekobako.MaskTextureEditor.Editor
 {
     internal class UvMapDrawer : ScriptableObject
     {
+        private const string k_NormalOverlayShaderName = "Hidden/MaskTextureEditor/NormalOverlay";
+
         [SerializeField]
         private Renderer? m_Renderer = null;
 
@@ -45,11 +47,19 @@ namespace net.nekobako.MaskTextureEditor.Editor
         private Vector3[]? m_Buffer = null;
         private int[]? m_LineIndices = null;
         private int[]? m_TriangleIndices = null;
+        private Color[]? m_NormalColors = null;
+
+        [SerializeField]
+        private RenderTexture m_NormalOverlay = null!;
+
+        [SerializeField]
+        private Material m_NormalOverlayMaterial = null!;
 
         private void Awake()
         {
             // Set HideFlags to keep the state when reloading a scene or domain
             hideFlags = HideFlags.HideAndDontSave;
+            EnsureNormalOverlayMaterial();
         }
 
         public void Init(Renderer? renderer, int? slot)
@@ -58,7 +68,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
             m_Slot = slot ?? 0;
         }
 
-        public void Draw(Rect rect)
+        public void Draw(Rect rect, Vector2Int textureSize, bool showUvWireframe, bool showNormalOverlay, float normalOverlayOpacity)
         {
             var (mesh, material) = CollectMeshAndMaterial();
             if (m_IsDirty ||
@@ -68,8 +78,9 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 m_IsDirty = false;
                 m_Mesh = mesh;
                 m_MeshDirtyCount = EditorUtility.GetDirtyCount(m_Mesh);
-                (m_Points, m_LineIndices, m_TriangleIndices) = CollectMeshData();
+                (m_Points, m_LineIndices, m_TriangleIndices, m_NormalColors) = CollectMeshData();
                 m_Buffer = m_Points != null ? new Vector3[m_Points.Length] : null;
+                ReleaseNormalOverlay();
             }
 
             if (material != null && material.mainTexture != null)
@@ -78,7 +89,15 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 EditorGUI.DrawTextureTransparent(rect, material.mainTexture);
             }
 
-            if (m_Points != null && m_Buffer != null && m_LineIndices != null)
+            if (showNormalOverlay && TryRenderNormalOverlay(textureSize))
+            {
+                var color = GUI.color;
+                GUI.color = new(color.r, color.g, color.b, color.a * normalOverlayOpacity);
+                GUI.DrawTexture(rect, m_NormalOverlay, ScaleMode.StretchToFill, true);
+                GUI.color = color;
+            }
+
+            if (showUvWireframe && m_Points != null && m_Buffer != null && m_LineIndices != null)
             {
                 // Draw line shadows for visibility
                 for (var i = 0; i < m_Buffer.Length; i++)
@@ -96,6 +115,69 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 Handles.color = GUI.color * Color.white;
                 Handles.DrawLines(m_Buffer, m_LineIndices);
             }
+        }
+
+        private bool TryRenderNormalOverlay(Vector2Int textureSize)
+        {
+            if (m_Points == null ||
+                m_TriangleIndices == null ||
+                m_NormalColors == null ||
+                textureSize.x <= 0 ||
+                textureSize.y <= 0)
+            {
+                return false;
+            }
+
+            if (m_NormalOverlay != null &&
+                m_NormalOverlay.width == textureSize.x &&
+                m_NormalOverlay.height == textureSize.y)
+            {
+                return true;
+            }
+
+            ReleaseNormalOverlay();
+            EnsureNormalOverlayMaterial();
+            m_NormalOverlay = new(textureSize.x, textureSize.y, 0, RenderTextureFormat.ARGB32)
+            {
+                hideFlags = HideFlags.HideAndDontSave,
+                filterMode = FilterMode.Bilinear,
+                wrapMode = TextureWrapMode.Clamp,
+            };
+            m_NormalOverlay.Create();
+
+            var previous = RenderTexture.active;
+            RenderTexture.active = m_NormalOverlay;
+            GL.Clear(false, true, Color.clear);
+            GL.PushMatrix();
+            GL.LoadOrtho();
+            m_NormalOverlayMaterial.SetPass(0);
+            GL.Begin(GL.TRIANGLES);
+            for (var offset = 0; offset + 2 < m_TriangleIndices.Length; offset += 3)
+            {
+                GL.Color(m_NormalColors[offset]);
+                GL.Vertex3(m_Points[m_TriangleIndices[offset]].x, m_Points[m_TriangleIndices[offset]].y, 0.0f);
+                GL.Color(m_NormalColors[offset + 1]);
+                GL.Vertex3(m_Points[m_TriangleIndices[offset + 1]].x, m_Points[m_TriangleIndices[offset + 1]].y, 0.0f);
+                GL.Color(m_NormalColors[offset + 2]);
+                GL.Vertex3(m_Points[m_TriangleIndices[offset + 2]].x, m_Points[m_TriangleIndices[offset + 2]].y, 0.0f);
+            }
+            GL.End();
+            GL.PopMatrix();
+            RenderTexture.active = previous;
+            return true;
+        }
+
+        private void EnsureNormalOverlayMaterial()
+        {
+            if (m_NormalOverlayMaterial != null)
+            {
+                return;
+            }
+
+            m_NormalOverlayMaterial = new(Shader.Find(k_NormalOverlayShaderName))
+            {
+                hideFlags = HideFlags.HideAndDontSave,
+            };
         }
 
         public bool TryGetTriangles(out Vector2[] points, out int[] indices)
@@ -144,16 +226,16 @@ namespace net.nekobako.MaskTextureEditor.Editor
             }
         }
 
-        private (Vector2[]?, int[]?, int[]?) CollectMeshData()
+        private (Vector2[]?, int[]?, int[]?, Color[]?) CollectMeshData()
         {
             if (m_Mesh == null)
             {
-                return (null, null, null);
+                return (null, null, null, null);
             }
 
             if (m_Mesh.subMeshCount == 0)
             {
-                return (null, null, null);
+                return (null, null, null, null);
             }
 
             var subMesh = Mathf.Clamp(m_Slot, 0, m_Mesh.subMeshCount - 1);
@@ -167,7 +249,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
             };
             if (topology == 0)
             {
-                return (null, null, null);
+                return (null, null, null, null);
             }
 
             var lines = new HashSet<(int, int)>();
@@ -186,10 +268,74 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 lineIndices.Add(b);
             }
 
-            return (
-                m_Mesh.uv,
-                lineIndices.ToArray(),
-                meshTopology == MeshTopology.Triangles ? indices : null);
+            if (meshTopology != MeshTopology.Triangles)
+            {
+                return (m_Mesh.uv, lineIndices.ToArray(), null, null);
+            }
+
+            var vertices = m_Mesh.vertices;
+            var normals = m_Mesh.normals;
+            var hasVertexNormals = normals.Length == vertices.Length;
+            var normalColors = new Color[indices.Length];
+            for (var offset = 0; offset + 2 < indices.Length; offset += 3)
+            {
+                var a = vertices[indices[offset]];
+                var b = vertices[indices[offset + 1]];
+                var c = vertices[indices[offset + 2]];
+                var cross = Vector3.Cross(b - a, c - a);
+                if (cross.sqrMagnitude <= Mathf.Epsilon)
+                {
+                    normalColors[offset] = Color.clear;
+                    normalColors[offset + 1] = Color.clear;
+                    normalColors[offset + 2] = Color.clear;
+                    continue;
+                }
+
+                var faceNormal = cross.normalized;
+                for (var corner = 0; corner < 3; corner++)
+                {
+                    var normal = hasVertexNormals ? normals[indices[offset + corner]] : faceNormal;
+                    if (normal.sqrMagnitude <= Mathf.Epsilon)
+                    {
+                        normal = faceNormal;
+                    }
+                    normalColors[offset + corner] = EncodeNormal(normal);
+                }
+            }
+
+            return (m_Mesh.uv, lineIndices.ToArray(), indices, normalColors);
+        }
+
+        private static Color EncodeNormal(Vector3 normal)
+        {
+            normal.Normalize();
+            return new(
+                    normal.x * 0.5f + 0.5f,
+                    normal.y * 0.5f + 0.5f,
+                    normal.z * 0.5f + 0.5f,
+                    1.0f);
+        }
+
+        private void ReleaseNormalOverlay()
+        {
+            if (m_NormalOverlay == null)
+            {
+                return;
+            }
+
+            DestroyImmediate(m_NormalOverlay);
+            m_NormalOverlay = null!;
+        }
+
+        private void OnDestroy()
+        {
+            ReleaseNormalOverlay();
+
+            if (m_NormalOverlayMaterial != null)
+            {
+                DestroyImmediate(m_NormalOverlayMaterial);
+                m_NormalOverlayMaterial = null!;
+            }
         }
     }
 }

--- a/Packages/net.nekobako.mask-texture-editor/Editor/UvMapDrawer.cs
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/UvMapDrawer.cs
@@ -9,6 +9,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
         private const string k_NormalOverlayShaderName = "Hidden/MaskTextureEditor/NormalOverlay";
         private const string k_SelectionMaskShaderName = "Hidden/MaskTextureEditor/SelectionOverlay";
         private const float k_SelectionOverlayOpacity = 0.4f;
+        private const float k_SelectionMaskPadding = 0.75f;
 
         [SerializeField]
         private Renderer? m_Renderer = null;
@@ -246,9 +247,12 @@ namespace net.nekobako.MaskTextureEditor.Editor
             foreach (var triangle in m_Data.Topology.GetIslandTriangles(m_ActiveIsland))
             {
                 var offset = triangle * 3;
-                GL.Vertex3(m_Data.Points[m_Data.TriangleIndices[offset]].x, m_Data.Points[m_Data.TriangleIndices[offset]].y, 0.0f);
-                GL.Vertex3(m_Data.Points[m_Data.TriangleIndices[offset + 1]].x, m_Data.Points[m_Data.TriangleIndices[offset + 1]].y, 0.0f);
-                GL.Vertex3(m_Data.Points[m_Data.TriangleIndices[offset + 2]].x, m_Data.Points[m_Data.TriangleIndices[offset + 2]].y, 0.0f);
+                TexturePainter.EmitPaddedUvTriangle(
+                    m_Data.Points,
+                    m_Data.TriangleIndices,
+                    offset,
+                    new(textureSize.x, textureSize.y),
+                    k_SelectionMaskPadding);
             }
             GL.End();
             GL.PopMatrix();
@@ -316,20 +320,6 @@ namespace net.nekobako.MaskTextureEditor.Editor
 
             m_ActiveIsland = -1;
             ReleaseSelectionMask();
-        }
-
-        public bool TryGetActiveIsland(out MeshUvData data, out IReadOnlyList<int> triangles)
-        {
-            if (m_ActiveIsland >= 0 && m_Data?.Topology != null)
-            {
-                data = m_Data;
-                triangles = m_Data.Topology.GetIslandTriangles(m_ActiveIsland);
-                return true;
-            }
-
-            data = null!;
-            triangles = null!;
-            return false;
         }
 
         private (Mesh?, Material?) CollectMeshAndMaterial()

--- a/Packages/net.nekobako.mask-texture-editor/Editor/UvMapDrawer.cs
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/UvMapDrawer.cs
@@ -44,6 +44,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
         private Vector2[]? m_Points = null;
         private Vector3[]? m_Buffer = null;
         private int[]? m_LineIndices = null;
+        private int[]? m_TriangleIndices = null;
 
         private void Awake()
         {
@@ -67,7 +68,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 m_IsDirty = false;
                 m_Mesh = mesh;
                 m_MeshDirtyCount = EditorUtility.GetDirtyCount(m_Mesh);
-                (m_Points, m_LineIndices) = CollectPointsAndLineIndices();
+                (m_Points, m_LineIndices, m_TriangleIndices) = CollectMeshData();
                 m_Buffer = m_Points != null ? new Vector3[m_Points.Length] : null;
             }
 
@@ -97,6 +98,20 @@ namespace net.nekobako.MaskTextureEditor.Editor
             }
         }
 
+        public bool TryGetTriangles(out Vector2[] points, out int[] indices)
+        {
+            if (m_Points != null && m_TriangleIndices != null)
+            {
+                points = m_Points;
+                indices = m_TriangleIndices;
+                return true;
+            }
+
+            points = null!;
+            indices = null!;
+            return false;
+        }
+
         private (Mesh?, Material?) CollectMeshAndMaterial()
         {
             if (m_Renderer == null)
@@ -109,13 +124,17 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 case MeshRenderer meshRenderer:
                 {
                     var mesh = meshRenderer.TryGetComponent<MeshFilter>(out var filter) ? filter.sharedMesh : null;
-                    var material = m_Slot < meshRenderer.sharedMaterials.Length ? meshRenderer.sharedMaterials[m_Slot] : null;
+                    var material = m_Slot >= 0 && m_Slot < meshRenderer.sharedMaterials.Length
+                        ? meshRenderer.sharedMaterials[m_Slot]
+                        : null;
                     return (mesh, material);
                 }
                 case SkinnedMeshRenderer skinnedMeshRenderer:
                 {
                     var mesh = skinnedMeshRenderer.sharedMesh;
-                    var material = m_Slot < skinnedMeshRenderer.sharedMaterials.Length ? skinnedMeshRenderer.sharedMaterials[m_Slot] : null;
+                    var material = m_Slot >= 0 && m_Slot < skinnedMeshRenderer.sharedMaterials.Length
+                        ? skinnedMeshRenderer.sharedMaterials[m_Slot]
+                        : null;
                     return (mesh, material);
                 }
                 default:
@@ -125,14 +144,21 @@ namespace net.nekobako.MaskTextureEditor.Editor
             }
         }
 
-        private (Vector2[]?, int[]?) CollectPointsAndLineIndices()
+        private (Vector2[]?, int[]?, int[]?) CollectMeshData()
         {
             if (m_Mesh == null)
             {
-                return (null, null);
+                return (null, null, null);
             }
 
-            var topology = m_Mesh.GetTopology(Mathf.Min(m_Slot, m_Mesh.subMeshCount - 1)) switch
+            if (m_Mesh.subMeshCount == 0)
+            {
+                return (null, null, null);
+            }
+
+            var subMesh = Mathf.Clamp(m_Slot, 0, m_Mesh.subMeshCount - 1);
+            var meshTopology = m_Mesh.GetTopology(subMesh);
+            var topology = meshTopology switch
             {
                 MeshTopology.Lines => 2,
                 MeshTopology.Triangles => 3,
@@ -141,11 +167,11 @@ namespace net.nekobako.MaskTextureEditor.Editor
             };
             if (topology == 0)
             {
-                return (null, null);
+                return (null, null, null);
             }
 
             var lines = new HashSet<(int, int)>();
-            var indices = m_Mesh.GetIndices(Mathf.Min(m_Slot, m_Mesh.subMeshCount - 1));
+            var indices = m_Mesh.GetIndices(subMesh);
             for (var i = 0; i < indices.Length; i++)
             {
                 var indexA = indices[i / topology * topology + (i + 0) % topology];
@@ -160,7 +186,10 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 lineIndices.Add(b);
             }
 
-            return (m_Mesh.uv, lineIndices.ToArray());
+            return (
+                m_Mesh.uv,
+                lineIndices.ToArray(),
+                meshTopology == MeshTopology.Triangles ? indices : null);
         }
     }
 }

--- a/Packages/net.nekobako.mask-texture-editor/Editor/UvTopology.cs
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/UvTopology.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace net.nekobako.MaskTextureEditor.Editor
+{
+    internal sealed class UvTopology
+    {
+        private const float k_UvTolerance = 0.00001f;
+
+        private readonly struct UvKey : IEquatable<UvKey>, IComparable<UvKey>
+        {
+            private readonly int m_X;
+            private readonly int m_Y;
+
+            public UvKey(Vector2 point)
+            {
+                m_X = Mathf.RoundToInt(point.x / k_UvTolerance);
+                m_Y = Mathf.RoundToInt(point.y / k_UvTolerance);
+            }
+
+            public int CompareTo(UvKey other)
+            {
+                var x = m_X.CompareTo(other.m_X);
+                return x != 0 ? x : m_Y.CompareTo(other.m_Y);
+            }
+
+            public bool Equals(UvKey other)
+            {
+                return m_X == other.m_X && m_Y == other.m_Y;
+            }
+
+            public override bool Equals(object? obj)
+            {
+                return obj is UvKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return (m_X * 397) ^ m_Y;
+                }
+            }
+        }
+
+        private readonly struct UvEdge : IEquatable<UvEdge>
+        {
+            private readonly UvKey m_A;
+            private readonly UvKey m_B;
+
+            public UvEdge(Vector2 a, Vector2 b)
+            {
+                var keyA = new UvKey(a);
+                var keyB = new UvKey(b);
+                if (keyA.CompareTo(keyB) <= 0)
+                {
+                    m_A = keyA;
+                    m_B = keyB;
+                }
+                else
+                {
+                    m_A = keyB;
+                    m_B = keyA;
+                }
+            }
+
+            public bool Equals(UvEdge other)
+            {
+                return m_A.Equals(other.m_A) && m_B.Equals(other.m_B);
+            }
+
+            public override bool Equals(object? obj)
+            {
+                return obj is UvEdge other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return (m_A.GetHashCode() * 397) ^ m_B.GetHashCode();
+                }
+            }
+        }
+
+        private readonly Vector2[] m_Points;
+        private readonly int[] m_Indices;
+        private readonly int[] m_IslandByTriangle;
+        private readonly List<int[]> m_Islands = new();
+
+        public int IslandCount => m_Islands.Count;
+
+        public UvTopology(Vector2[] points, int[] indices)
+        {
+            m_Points = points;
+            m_Indices = indices;
+
+            var triangleCount = indices.Length / 3;
+            var parents = new int[triangleCount];
+            var ranks = new byte[triangleCount];
+            var valid = new bool[triangleCount];
+            var edges = new Dictionary<UvEdge, int>();
+            for (var triangle = 0; triangle < triangleCount; triangle++)
+            {
+                parents[triangle] = triangle;
+
+                var offset = triangle * 3;
+                var indexA = indices[offset];
+                var indexB = indices[offset + 1];
+                var indexC = indices[offset + 2];
+                if (!IsValidIndex(indexA) || !IsValidIndex(indexB) || !IsValidIndex(indexC))
+                {
+                    continue;
+                }
+
+                var pointA = m_Points[indexA];
+                var pointB = m_Points[indexB];
+                var pointC = m_Points[indexC];
+                if (Mathf.Abs(Cross(pointB - pointA, pointC - pointA)) <= k_UvTolerance * k_UvTolerance)
+                {
+                    continue;
+                }
+
+                valid[triangle] = true;
+                ConnectEdge(new(pointA, pointB), triangle, edges, parents, ranks);
+                ConnectEdge(new(pointB, pointC), triangle, edges, parents, ranks);
+                ConnectEdge(new(pointC, pointA), triangle, edges, parents, ranks);
+            }
+
+            m_IslandByTriangle = new int[triangleCount];
+            Array.Fill(m_IslandByTriangle, -1);
+            var islandByRoot = new Dictionary<int, int>();
+            var islandTriangles = new List<List<int>>();
+            for (var triangle = 0; triangle < triangleCount; triangle++)
+            {
+                if (!valid[triangle])
+                {
+                    continue;
+                }
+
+                var root = Find(triangle, parents);
+                if (!islandByRoot.TryGetValue(root, out var island))
+                {
+                    island = islandTriangles.Count;
+                    islandByRoot.Add(root, island);
+                    islandTriangles.Add(new());
+                }
+
+                m_IslandByTriangle[triangle] = island;
+                islandTriangles[island].Add(triangle);
+            }
+
+            foreach (var triangles in islandTriangles)
+            {
+                m_Islands.Add(triangles.ToArray());
+            }
+        }
+
+        public bool TryFindIsland(Vector2 point, out int island)
+        {
+            for (var triangle = 0; triangle < m_IslandByTriangle.Length; triangle++)
+            {
+                if (m_IslandByTriangle[triangle] < 0)
+                {
+                    continue;
+                }
+
+                var offset = triangle * 3;
+                if (PointInTriangle(
+                    point,
+                    m_Points[m_Indices[offset]],
+                    m_Points[m_Indices[offset + 1]],
+                    m_Points[m_Indices[offset + 2]]))
+                {
+                    island = m_IslandByTriangle[triangle];
+                    return true;
+                }
+            }
+
+            island = -1;
+            return false;
+        }
+
+        public IReadOnlyList<int> GetIslandTriangles(int island)
+        {
+            return island >= 0 && island < m_Islands.Count
+                ? m_Islands[island]
+                : Array.Empty<int>();
+        }
+
+        private bool IsValidIndex(int index)
+        {
+            return index >= 0 && index < m_Points.Length;
+        }
+
+        private static void ConnectEdge(
+            UvEdge edge,
+            int triangle,
+            Dictionary<UvEdge, int> edges,
+            int[] parents,
+            byte[] ranks)
+        {
+            if (edges.TryGetValue(edge, out var neighbor))
+            {
+                Union(triangle, neighbor, parents, ranks);
+            }
+            else
+            {
+                edges.Add(edge, triangle);
+            }
+        }
+
+        private static int Find(int value, int[] parents)
+        {
+            while (parents[value] != value)
+            {
+                parents[value] = parents[parents[value]];
+                value = parents[value];
+            }
+            return value;
+        }
+
+        private static void Union(int a, int b, int[] parents, byte[] ranks)
+        {
+            var rootA = Find(a, parents);
+            var rootB = Find(b, parents);
+            if (rootA == rootB)
+            {
+                return;
+            }
+
+            if (ranks[rootA] < ranks[rootB])
+            {
+                parents[rootA] = rootB;
+            }
+            else if (ranks[rootA] > ranks[rootB])
+            {
+                parents[rootB] = rootA;
+            }
+            else
+            {
+                parents[rootB] = rootA;
+                ranks[rootA]++;
+            }
+        }
+
+        private static bool PointInTriangle(Vector2 point, Vector2 a, Vector2 b, Vector2 c)
+        {
+            var ab = Cross(b - a, point - a);
+            var bc = Cross(c - b, point - b);
+            var ca = Cross(a - c, point - c);
+            return
+                (ab >= 0.0f && bc >= 0.0f && ca >= 0.0f) ||
+                (ab <= 0.0f && bc <= 0.0f && ca <= 0.0f);
+        }
+
+        private static float Cross(Vector2 a, Vector2 b)
+        {
+            return a.x * b.y - a.y * b.x;
+        }
+    }
+}

--- a/Packages/net.nekobako.mask-texture-editor/Editor/UvTopology.cs.meta
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/UvTopology.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 52005a5947194844be7097d02164dd14

--- a/Packages/net.nekobako.mask-texture-editor/Editor/Window.cs
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/Window.cs
@@ -97,6 +97,15 @@ namespace net.nekobako.MaskTextureEditor.Editor
         private float m_ViewOpacity = 0.5f;
 
         [SerializeField]
+        private bool m_ShowUvPreview = true;
+
+        [SerializeField]
+        private bool m_ShowNormalOverlay = true;
+
+        [SerializeField]
+        private float m_NormalOverlayOpacity = 0.35f;
+
+        [SerializeField]
         private bool m_RequestResetView = true;
 
         [SerializeField]
@@ -361,6 +370,20 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 CL4EE.Tr("view-opacity"),
                 m_ViewOpacity, k_ViewOpacityMin, k_ViewOpacityMax);
 
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                EditorGUILayout.PrefixLabel(CL4EE.Tr("preview-layers"));
+                m_ShowUvPreview = GUILayout.Toggle(m_ShowUvPreview, CL4EE.Tr("uv-preview"), Styles.Toggle);
+                m_ShowNormalOverlay = GUILayout.Toggle(m_ShowNormalOverlay, CL4EE.Tr("normal-overlay"), Styles.Toggle);
+            }
+
+            using (new EditorGUI.DisabledScope(!m_ShowNormalOverlay))
+            {
+                m_NormalOverlayOpacity = EditorGUILayout.Slider(
+                    CL4EE.Tr("normal-overlay-opacity"),
+                    m_NormalOverlayOpacity, 0.0f, 1.0f);
+            }
+
             EditorGUILayout.Space();
 
             using (new EditorGUILayout.HorizontalScope())
@@ -448,7 +471,12 @@ namespace net.nekobako.MaskTextureEditor.Editor
         private void DrawContents(Rect rect, bool brush)
         {
             GUI.color = new(1.0f, 1.0f, 1.0f, 1.0f);
-            m_UvMapDrawer.Draw(rect);
+            m_UvMapDrawer.Draw(
+                rect,
+                Vector2Int.RoundToInt(m_TexturePainter.TextureSize),
+                m_ShowUvPreview,
+                m_ShowNormalOverlay,
+                m_NormalOverlayOpacity);
 
             GUI.color = new(1.0f, 1.0f, 1.0f, m_ViewOpacity);
             m_TexturePainter.Draw(rect, brush);

--- a/Packages/net.nekobako.mask-texture-editor/Editor/Window.cs
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/Window.cs
@@ -102,6 +102,8 @@ namespace net.nekobako.MaskTextureEditor.Editor
         [SerializeField]
         private int m_SavedTextureInstanceId = 0;
 
+        private bool m_IsPaintingStroke = false;
+
 #if MTE_NDMF
         public static readonly PublishedValue<bool> IsOpen = new(false);
 
@@ -153,6 +155,14 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 (token == null || window.m_Token == token);
         }
 
+        internal static void RepaintIfOpen()
+        {
+            if (HasOpenInstances<Window>())
+            {
+                GetWindow<Window>(string.Empty, false).Repaint();
+            }
+        }
+
         public static void TryOpen(Texture2D texture, Renderer? renderer = null, int? slot = null, string? token = null)
         {
             TryClose();
@@ -188,16 +198,16 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 CL4EE.Tr("save-changes-button-discard")))
             {
                 case 0:
-                {
-                    window.SaveChanges();
-                    window.Close();
-                    return;
-                }
+                    {
+                        window.SaveChanges();
+                        window.Close();
+                        return;
+                    }
                 case 2:
-                {
-                    window.Close();
-                    return;
-                }
+                    {
+                        window.Close();
+                        return;
+                    }
             }
         }
 
@@ -353,13 +363,26 @@ namespace net.nekobako.MaskTextureEditor.Editor
 
             EditorGUILayout.Space();
 
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                EditorGUILayout.PrefixLabel(CL4EE.Tr("brush-mode"));
+
+                var modes = new[] { BrushMode.Circle, BrushMode.Triangle };
+                var texts = new[] { CL4EE.Tr("brush-mode-circle"), CL4EE.Tr("brush-mode-triangle") };
+                var index = Array.IndexOf(modes, m_TexturePainter.BrushMode);
+                m_TexturePainter.BrushMode = modes[GUILayout.Toolbar(index, texts)];
+            }
+
             m_TexturePainter.BrushSize = EditorGUILayout.Slider(
                 CL4EE.Tr("brush-size"),
                 m_TexturePainter.BrushSize, k_BrushSizeMin, k_BrushSizeMax);
 
-            m_TexturePainter.BrushHardness = EditorGUILayout.Slider(
-                CL4EE.Tr("brush-hardness"),
-                m_TexturePainter.BrushHardness, k_BrushHardnessMin, k_BrushHardnessMax);
+            using (new EditorGUI.DisabledScope(m_TexturePainter.BrushMode == BrushMode.Triangle))
+            {
+                m_TexturePainter.BrushHardness = EditorGUILayout.Slider(
+                    CL4EE.Tr("brush-hardness"),
+                    m_TexturePainter.BrushHardness, k_BrushHardnessMin, k_BrushHardnessMax);
+            }
 
             m_TexturePainter.BrushStrength = EditorGUILayout.Slider(
                 CL4EE.Tr("brush-strength"),
@@ -438,130 +461,151 @@ namespace net.nekobako.MaskTextureEditor.Editor
             switch (type)
             {
                 case EventType.Repaint:
-                {
-                    if (m_RequestResetView)
                     {
-                        // Fit the view to the window
-                        m_ViewScale = Mathf.Min(
-                            rect.size.x / m_TexturePainter.TextureSize.x,
-                            rect.size.y / m_TexturePainter.TextureSize.y);
-                        m_ViewScale = Mathf.Clamp(m_ViewScale, k_ViewScaleMin, k_ViewScaleMax);
-                        m_ViewPosition = m_TexturePainter.TextureSize * (m_ViewScale * 0.5f);
-                        m_RequestResetView = false;
-                        Repaint();
+                        if (m_RequestResetView)
+                        {
+                            // Fit the view to the window
+                            m_ViewScale = Mathf.Min(
+                                rect.size.x / m_TexturePainter.TextureSize.x,
+                                rect.size.y / m_TexturePainter.TextureSize.y);
+                            m_ViewScale = Mathf.Clamp(m_ViewScale, k_ViewScaleMin, k_ViewScaleMax);
+                            m_ViewPosition = m_TexturePainter.TextureSize * (m_ViewScale * 0.5f);
+                            m_RequestResetView = false;
+                            Repaint();
+                        }
+                        break;
                     }
-                    break;
-                }
                 case EventType.MouseMove:
-                {
-                    Repaint();
-                    break;
-                }
+                    {
+                        Repaint();
+                        break;
+                    }
                 case EventType.MouseDown when rect.Contains(Event.current.mousePosition):
-                {
-                    // Set HotControl to continue dragging outside the window
-                    GUIUtility.hotControl = control;
-
-                    if (Events.Paint)
                     {
-                        // Paint the texture
-                        var pos = Event.current.mousePosition - rect.center + m_ViewPosition;
-                        m_TexturePainter.Paint(pos / m_ViewScale, false);
+                        // Set HotControl to continue dragging outside the window
+                        GUIUtility.hotControl = control;
+
+                        if (Events.Paint)
+                        {
+                            // Paint the texture
+                            var pos = Event.current.mousePosition - rect.center + m_ViewPosition;
+                            GetUvTriangles(out var points, out var indices);
+                            m_TexturePainter.BeginStroke(pos / m_ViewScale, points, indices);
+                            m_IsPaintingStroke = true;
+                        }
+                        Repaint();
+                        break;
                     }
-                    Repaint();
-                    break;
-                }
                 case EventType.MouseUp when GUIUtility.hotControl == control:
-                {
-                    // Unset HotControl to allow other controls to respond
-                    GUIUtility.hotControl = 0;
+                    {
+                        // Unset HotControl to allow other controls to respond
+                        GUIUtility.hotControl = 0;
 
-                    if (Events.Paint)
-                    {
-                        m_TextureUndoStack.Record();
+                        if (m_IsPaintingStroke)
+                        {
+                            if (m_TexturePainter.EndStroke())
+                            {
+                                m_TextureUndoStack.Record();
+                            }
+                            m_IsPaintingStroke = false;
+                        }
+                        Repaint();
+                        break;
                     }
-                    Repaint();
-                    break;
-                }
                 case EventType.MouseDrag when GUIUtility.hotControl == control:
-                {
-                    var delta = Event.current.delta;
-                    if (Events.Paint)
                     {
-                        // Paint the texture
-                        var pos = Event.current.mousePosition - rect.center + m_ViewPosition;
-                        m_TexturePainter.Paint(pos / m_ViewScale, true);
+                        var delta = Event.current.delta;
+                        if (m_IsPaintingStroke)
+                        {
+                            // Paint the texture
+                            var pos = Event.current.mousePosition - rect.center + m_ViewPosition;
+                            GetUvTriangles(out var points, out var indices);
+                            m_TexturePainter.ContinueStroke(pos / m_ViewScale, points, indices);
+                        }
+                        else
+                        {
+                            // Move the view
+                            m_ViewPosition -= delta;
+                        }
+                        Repaint();
+                        break;
                     }
-                    else
-                    {
-                        // Move the view
-                        m_ViewPosition -= delta;
-                    }
-                    Repaint();
-                    break;
-                }
                 case EventType.ScrollWheel when rect.Contains(Event.current.mousePosition):
-                {
-                    var delta = Event.current.delta.x + Event.current.delta.y;
-                    if (Events.ViewScale)
                     {
-                        // Scale the view
-                        var prev = m_ViewScale;
-                        m_ViewScale *= 1.0f - delta * k_ViewScaleFactor;
-                        m_ViewScale = Mathf.Clamp(m_ViewScale, k_ViewScaleMin, k_ViewScaleMax);
-                        m_ViewPosition -= m_ViewPosition * (1.0f - m_ViewScale / prev);
+                        var delta = Event.current.delta.x + Event.current.delta.y;
+                        if (Events.ViewScale)
+                        {
+                            // Scale the view
+                            var prev = m_ViewScale;
+                            m_ViewScale *= 1.0f - delta * k_ViewScaleFactor;
+                            m_ViewScale = Mathf.Clamp(m_ViewScale, k_ViewScaleMin, k_ViewScaleMax);
+                            m_ViewPosition -= m_ViewPosition * (1.0f - m_ViewScale / prev);
+                        }
+                        else if (Events.ViewOpacity)
+                        {
+                            // Adjust the view opacity
+                            m_ViewOpacity -= delta * k_ViewOpacityFactor;
+                            m_ViewOpacity = Mathf.Clamp(m_ViewOpacity, k_ViewOpacityMin, k_ViewOpacityMax);
+                        }
+                        else if (Events.BrushSize)
+                        {
+                            // Adjust the brush size
+                            m_TexturePainter.BrushSize *= 1.0f - delta * k_BrushSizeFactor;
+                            m_TexturePainter.BrushSize = Mathf.Clamp(m_TexturePainter.BrushSize, k_BrushSizeMin, k_BrushSizeMax);
+                        }
+                        else if (Events.BrushHardness)
+                        {
+                            // Adjust the brush hardness
+                            m_TexturePainter.BrushHardness -= delta * k_BrushHardnessFactor;
+                            m_TexturePainter.BrushHardness = Mathf.Clamp(m_TexturePainter.BrushHardness, k_BrushHardnessMin, k_BrushHardnessMax);
+                        }
+                        else if (Events.BrushStrength)
+                        {
+                            // Adjust the brush strength
+                            m_TexturePainter.BrushStrength -= delta * k_BrushStrengthFactor;
+                            m_TexturePainter.BrushStrength = Mathf.Clamp(m_TexturePainter.BrushStrength, k_BrushStrengthMin, k_BrushStrengthMax);
+                        }
+                        else if (Events.BrushDensity)
+                        {
+                            // Adjust the brush density
+                            m_TexturePainter.BrushDensity *= 1.0f - delta * k_BrushDensityFactor;
+                            m_TexturePainter.BrushDensity = Mathf.Clamp(m_TexturePainter.BrushDensity, k_BrushDensityMin, k_BrushDensityMax);
+                        }
+                        else
+                        {
+                            // Scale the view around the mouse position
+                            var prev = m_ViewScale;
+                            m_ViewScale *= 1.0f - delta * k_ViewScaleFactor;
+                            m_ViewScale = Mathf.Clamp(m_ViewScale, k_ViewScaleMin, k_ViewScaleMax);
+                            var pos = Event.current.mousePosition - rect.center + m_ViewPosition;
+                            m_ViewPosition -= pos * (1.0f - m_ViewScale / prev);
+                        }
+                        Repaint();
+                        break;
                     }
-                    else if (Events.ViewOpacity)
-                    {
-                        // Adjust the view opacity
-                        m_ViewOpacity -= delta * k_ViewOpacityFactor;
-                        m_ViewOpacity = Mathf.Clamp(m_ViewOpacity, k_ViewOpacityMin, k_ViewOpacityMax);
-                    }
-                    else if (Events.BrushSize)
-                    {
-                        // Adjust the brush size
-                        m_TexturePainter.BrushSize *= 1.0f - delta * k_BrushSizeFactor;
-                        m_TexturePainter.BrushSize = Mathf.Clamp(m_TexturePainter.BrushSize, k_BrushSizeMin, k_BrushSizeMax);
-                    }
-                    else if (Events.BrushHardness)
-                    {
-                        // Adjust the brush hardness
-                        m_TexturePainter.BrushHardness -= delta * k_BrushHardnessFactor;
-                        m_TexturePainter.BrushHardness = Mathf.Clamp(m_TexturePainter.BrushHardness, k_BrushHardnessMin, k_BrushHardnessMax);
-                    }
-                    else if (Events.BrushStrength)
-                    {
-                        // Adjust the brush strength
-                        m_TexturePainter.BrushStrength -= delta * k_BrushStrengthFactor;
-                        m_TexturePainter.BrushStrength = Mathf.Clamp(m_TexturePainter.BrushStrength, k_BrushStrengthMin, k_BrushStrengthMax);
-                    }
-                    else if (Events.BrushDensity)
-                    {
-                        // Adjust the brush density
-                        m_TexturePainter.BrushDensity *= 1.0f - delta * k_BrushDensityFactor;
-                        m_TexturePainter.BrushDensity = Mathf.Clamp(m_TexturePainter.BrushDensity, k_BrushDensityMin, k_BrushDensityMax);
-                    }
-                    else
-                    {
-                        // Scale the view around the mouse position
-                        var prev = m_ViewScale;
-                        m_ViewScale *= 1.0f - delta * k_ViewScaleFactor;
-                        m_ViewScale = Mathf.Clamp(m_ViewScale, k_ViewScaleMin, k_ViewScaleMax);
-                        var pos = Event.current.mousePosition - rect.center + m_ViewPosition;
-                        m_ViewPosition -= pos * (1.0f - m_ViewScale / prev);
-                    }
-                    Repaint();
-                    break;
-                }
                 case EventType.ValidateCommand:
-                {
-                    Repaint();
-                    break;
-                }
+                    {
+                        Repaint();
+                        break;
+                    }
             }
 
             // Ensure non-negative position to avoid scrollbars flickering
             m_ViewPosition = Vector2.Max(m_ViewPosition, Vector2.zero);
+        }
+
+        private void GetUvTriangles(out Vector2[]? points, out int[]? indices)
+        {
+            if (m_TexturePainter.BrushMode == BrushMode.Triangle &&
+                m_UvMapDrawer.TryGetTriangles(out var uvPoints, out var triangleIndices))
+            {
+                points = uvPoints;
+                indices = triangleIndices;
+                return;
+            }
+
+            points = null;
+            indices = null;
         }
 
         public override void SaveChanges()

--- a/Packages/net.nekobako.mask-texture-editor/Editor/Window.cs
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/Window.cs
@@ -13,6 +13,18 @@ namespace net.nekobako.MaskTextureEditor.Editor
 {
     public class Window : EditorWindow
     {
+        private enum ToolMode
+        {
+            Paint = 0,
+            Gradient = 2,
+        }
+
+        private enum OperationScope
+        {
+            WholeTexture,
+            UvIslandUnderCursor,
+        }
+
         private static class Styles
         {
             public static readonly GUIStyle Toolbar = new("Toolbar")
@@ -27,9 +39,9 @@ namespace net.nekobako.MaskTextureEditor.Editor
             {
                 fixedHeight = 24.0f,
             };
-            public static readonly GUIStyle LargeButton = new("button")
+            public static readonly GUIStyle CanvasToolbar = new(EditorStyles.toolbar)
             {
-                fixedHeight = 48.0f,
+                fixedHeight = 24.0f,
             };
         }
 
@@ -45,6 +57,9 @@ namespace net.nekobako.MaskTextureEditor.Editor
             public static bool BrushHardness => Event.current.alt && !Event.current.shift && (Event.current.control || Event.current.command);
             public static bool BrushStrength => !Event.current.alt && Event.current.shift && (Event.current.control || Event.current.command);
             public static bool BrushDensity => Event.current.alt && Event.current.shift && (Event.current.control || Event.current.command);
+            public static bool GradientWidth => !Event.current.alt && !Event.current.shift && (Event.current.control || Event.current.command);
+            public static bool GradientCurve => Event.current.alt && !Event.current.shift && (Event.current.control || Event.current.command);
+            public static bool GradientFeather => !Event.current.alt && Event.current.shift && (Event.current.control || Event.current.command);
         }
 
         private const float k_ViewScaleMin = 0.1f;
@@ -65,6 +80,17 @@ namespace net.nekobako.MaskTextureEditor.Editor
         private const float k_BrushDensityMin = 1.0f;
         private const float k_BrushDensityMax = 100.0f;
         private const float k_BrushDensityFactor = 0.1f;
+        private const float k_GradientCurveMin = 0.25f;
+        private const float k_GradientCurveMax = 8.0f;
+        private const float k_GradientCurveFactor = 0.1f;
+        private const float k_GradientWidthMin = 1.0f;
+        private const float k_GradientWidthMax = 512.0f;
+        private const float k_GradientWidthFactor = 0.1f;
+        private const float k_GradientFeatherMin = 0.0f;
+        private const float k_GradientFeatherMax = 512.0f;
+        private const float k_GradientFeatherFactor = 0.1f;
+        private const float k_SidebarWidth = 320.0f;
+        private const float k_CanvasToolbarCompactWidth = 800.0f;
 
         [SerializeField]
         private Texture2D m_Texture = null!; // Initialize in Open
@@ -106,12 +132,46 @@ namespace net.nekobako.MaskTextureEditor.Editor
         private float m_NormalOverlayOpacity = 0.35f;
 
         [SerializeField]
+        private ToolMode m_ToolMode = ToolMode.Paint;
+
+        [SerializeField]
+        private OperationScope m_PaintScope = OperationScope.WholeTexture;
+
+        [SerializeField]
+        private OperationScope m_GradientScope = OperationScope.UvIslandUnderCursor;
+
+        [SerializeField]
+        private GradientShape m_GradientShape = GradientShape.Band;
+
+        [SerializeField]
+        private float m_GradientStartValue = 0.0f;
+
+        [SerializeField]
+        private float m_GradientEndValue = 1.0f;
+
+        [SerializeField]
+        private float m_GradientCurveExponent = 1.0f;
+
+        [SerializeField]
+        private float m_GradientWidth = 128.0f;
+
+        [SerializeField]
+        private float m_GradientFeather = 32.0f;
+
+        [SerializeField]
+        private Vector2 m_SidebarScrollPosition = Vector2.zero;
+
+        [SerializeField]
         private bool m_RequestResetView = true;
 
         [SerializeField]
         private int m_SavedTextureInstanceId = 0;
 
         private bool m_IsPaintingStroke = false;
+        private bool m_IsGradientDragging = false;
+        private bool m_GradientModified = false;
+        private Vector2 m_GradientStart = Vector2.zero;
+        private Vector2 m_GradientEnd = Vector2.zero;
 
 #if MTE_NDMF
         public static readonly PublishedValue<bool> IsOpen = new(false);
@@ -259,6 +319,10 @@ namespace net.nekobako.MaskTextureEditor.Editor
 
         private void OnDisable()
         {
+            if (m_TexturePainter != null)
+            {
+                CancelActiveOperation();
+            }
             s_IsOpen = false;
 #if MTE_NDMF
             IsOpen.Value = false;
@@ -272,13 +336,23 @@ namespace net.nekobako.MaskTextureEditor.Editor
             hasUnsavedChanges = m_SavedTextureInstanceId != m_TextureUndoStack.Peek().GetInstanceID();
             saveChangesMessage = CL4EE.Tr("save-changes-message");
 
-            using var horizontal = position.width > position.height ? new EditorGUILayout.HorizontalScope() : null;
+            var horizontalLayout = position.width > position.height;
+            using var horizontal = horizontalLayout ? new EditorGUILayout.HorizontalScope() : null;
 
-            using (new EditorGUILayout.VerticalScope(Styles.Toolbar, horizontal != null ? GUILayout.Width(400.0f) : GUILayout.ExpandWidth(true)))
+            using (new EditorGUILayout.VerticalScope(
+                Styles.Toolbar,
+                horizontalLayout ? GUILayout.Width(k_SidebarWidth) : GUILayout.ExpandWidth(true)))
             {
-                DrawToolbar(horizontal != null);
+                DrawSidebar(horizontalLayout);
             }
 
+            using var canvas = new EditorGUILayout.VerticalScope();
+            DrawCanvasToolbar();
+            DrawCanvas();
+        }
+
+        private void DrawCanvas()
+        {
             var scrollRect = GUILayoutUtility.GetRect(
                 0.0f,
                 0.0f,
@@ -308,30 +382,49 @@ namespace net.nekobako.MaskTextureEditor.Editor
             HandleEvents(viewportRect);
         }
 
-        private void DrawToolbar(bool expand)
+        private void DrawSidebar(bool expand)
         {
-            EditorGUIUtility.labelWidth = 160.0f;
+            EditorGUIUtility.labelWidth = 100.0f;
 
+            EditorGUILayout.LabelField(CL4EE.Tr("texture"), EditorStyles.boldLabel);
             using (new EditorGUI.DisabledScope(true))
             {
                 EditorGUILayout.ObjectField(
-                    CL4EE.Tr("texture"),
-                    m_Texture, typeof(Texture2D), true, GUILayout.Height(EditorGUIUtility.singleLineHeight));
+                    m_Texture,
+                    typeof(Texture2D),
+                    true,
+                    GUILayout.Height(EditorGUIUtility.singleLineHeight));
             }
 
-            using (new EditorGUILayout.HorizontalScope())
+            using (var scroll = new EditorGUILayout.ScrollViewScope(
+                m_SidebarScrollPosition,
+                GUILayout.ExpandHeight(expand)))
             {
-                EditorGUILayout.PrefixLabel(CL4EE.Tr("color-mask"));
+                m_SidebarScrollPosition = scroll.scrollPosition;
 
-                var mask = ColorWriteMask.Alpha;
-                mask |= GUILayout.Toggle((m_TexturePainter.ColorMask & ColorWriteMask.Red) != 0, "R", Styles.Toggle) ? ColorWriteMask.Red : 0;
-                mask |= GUILayout.Toggle((m_TexturePainter.ColorMask & ColorWriteMask.Green) != 0, "G", Styles.Toggle) ? ColorWriteMask.Green : 0;
-                mask |= GUILayout.Toggle((m_TexturePainter.ColorMask & ColorWriteMask.Blue) != 0, "B", Styles.Toggle) ? ColorWriteMask.Blue : 0;
-                m_TexturePainter.ColorMask = mask;
+                EditorGUILayout.Space();
+                DrawTargetSettings();
+                EditorGUILayout.Space();
+                DrawToolSettings();
+                EditorGUILayout.Space();
+                DrawTextureOperations();
             }
 
-            EditorGUILayout.Space();
+            if (!expand)
+            {
+                EditorGUILayout.Space();
+            }
 
+            if (GUILayout.Button(CL4EE.Tr("save"), Styles.Button, GUILayout.Height(42.0f)))
+            {
+                SaveChanges();
+            }
+
+            CL4EE.DrawLanguagePicker();
+        }
+
+        private void DrawTargetSettings()
+        {
             using (new EditorGUI.DisabledScope(m_IsLockRenderer))
             {
                 m_UvMapDrawer.Renderer = EditorGUILayout.ObjectField(
@@ -351,40 +444,69 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 var index = Mathf.Clamp(m_UvMapDrawer.Slot, 0, texts.Length - 1);
                 m_UvMapDrawer.Slot = GUILayout.Toolbar(index, texts);
             }
+        }
 
-            EditorGUILayout.Space();
-
-            using (var check = new EditorGUI.ChangeCheckScope())
-            {
-                var prev = m_ViewScale;
-                m_ViewScale = EditorGUILayout.Slider(
-                    CL4EE.Tr("view-scale"),
-                    m_ViewScale, k_ViewScaleMin, k_ViewScaleMax);
-                if (check.changed)
-                {
-                    m_ViewPosition -= m_ViewPosition * (1.0f - m_ViewScale / prev);
-                }
-            }
-
-            m_ViewOpacity = EditorGUILayout.Slider(
-                CL4EE.Tr("view-opacity"),
-                m_ViewOpacity, k_ViewOpacityMin, k_ViewOpacityMax);
+        private void DrawToolSettings()
+        {
+            EditorGUILayout.LabelField(CL4EE.Tr("tool-mode"), EditorStyles.boldLabel);
 
             using (new EditorGUILayout.HorizontalScope())
             {
-                EditorGUILayout.PrefixLabel(CL4EE.Tr("preview-layers"));
-                m_ShowUvPreview = GUILayout.Toggle(m_ShowUvPreview, CL4EE.Tr("uv-preview"), Styles.Toggle);
-                m_ShowNormalOverlay = GUILayout.Toggle(m_ShowNormalOverlay, CL4EE.Tr("normal-overlay"), Styles.Toggle);
-            }
-
-            using (new EditorGUI.DisabledScope(!m_ShowNormalOverlay))
-            {
-                m_NormalOverlayOpacity = EditorGUILayout.Slider(
-                    CL4EE.Tr("normal-overlay-opacity"),
-                    m_NormalOverlayOpacity, 0.0f, 1.0f);
+                var modes = new[] { ToolMode.Paint, ToolMode.Gradient };
+                var texts = new[]
+                {
+                    CL4EE.Tr("tool-mode-paint"),
+                    CL4EE.Tr("tool-mode-gradient"),
+                };
+                var index = Array.IndexOf(modes, m_ToolMode);
+                index = Mathf.Max(index, 0);
+                var selected = modes[GUILayout.Toolbar(index, texts)];
+                if (selected != m_ToolMode)
+                {
+                    CancelActiveOperation();
+                    m_ToolMode = selected;
+                }
             }
 
             EditorGUILayout.Space();
+            switch (m_ToolMode)
+            {
+                case ToolMode.Paint:
+                    DrawPaintSettings();
+                    break;
+                case ToolMode.Gradient:
+                    DrawGradientSettings();
+                    break;
+            }
+        }
+
+        private void DrawColorChannels()
+        {
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                EditorGUILayout.PrefixLabel(CL4EE.Tr("color-mask"));
+
+                var mask = ColorWriteMask.Alpha;
+                mask |= GUILayout.Toggle((m_TexturePainter.ColorMask & ColorWriteMask.Red) != 0, "R", Styles.Toggle) ? ColorWriteMask.Red : 0;
+                mask |= GUILayout.Toggle((m_TexturePainter.ColorMask & ColorWriteMask.Green) != 0, "G", Styles.Toggle) ? ColorWriteMask.Green : 0;
+                mask |= GUILayout.Toggle((m_TexturePainter.ColorMask & ColorWriteMask.Blue) != 0, "B", Styles.Toggle) ? ColorWriteMask.Blue : 0;
+                m_TexturePainter.ColorMask = mask;
+            }
+        }
+
+        private OperationScope DrawScopePopup(OperationScope scope, string uvIslandLabel)
+        {
+            var scopes = new[] { OperationScope.WholeTexture, OperationScope.UvIslandUnderCursor };
+            var texts = new[] { CL4EE.Tr("scope-whole-texture"), CL4EE.Tr(uvIslandLabel) };
+            var index = Array.IndexOf(scopes, scope);
+            index = Mathf.Max(index, 0);
+            return scopes[EditorGUILayout.Popup(CL4EE.Tr("scope"), index, texts)];
+        }
+
+        private void DrawPaintSettings()
+        {
+            DrawColorChannels();
+            m_PaintScope = DrawScopePopup(m_PaintScope, "scope-uv-island-under-brush");
 
             using (new EditorGUILayout.HorizontalScope())
             {
@@ -397,22 +519,22 @@ namespace net.nekobako.MaskTextureEditor.Editor
             }
 
             m_TexturePainter.BrushSize = EditorGUILayout.Slider(
-                CL4EE.Tr("brush-size"),
+                new GUIContent(CL4EE.Tr("brush-size"), "Ctrl + Mouse Wheel"),
                 m_TexturePainter.BrushSize, k_BrushSizeMin, k_BrushSizeMax);
 
             using (new EditorGUI.DisabledScope(m_TexturePainter.BrushMode == BrushMode.Triangle))
             {
                 m_TexturePainter.BrushHardness = EditorGUILayout.Slider(
-                    CL4EE.Tr("brush-hardness"),
+                    new GUIContent(CL4EE.Tr("brush-hardness"), "Ctrl + Alt + Mouse Wheel"),
                     m_TexturePainter.BrushHardness, k_BrushHardnessMin, k_BrushHardnessMax);
             }
 
             m_TexturePainter.BrushStrength = EditorGUILayout.Slider(
-                CL4EE.Tr("brush-strength"),
+                new GUIContent(CL4EE.Tr("brush-strength"), "Ctrl + Shift + Mouse Wheel"),
                 m_TexturePainter.BrushStrength, k_BrushStrengthMin, k_BrushStrengthMax);
 
             m_TexturePainter.BrushDensity = EditorGUILayout.Slider(
-                CL4EE.Tr("brush-density"),
+                new GUIContent(CL4EE.Tr("brush-density"), "Ctrl + Alt + Shift + Mouse Wheel"),
                 m_TexturePainter.BrushDensity, k_BrushDensityMin, k_BrushDensityMax);
 
             using (new EditorGUILayout.HorizontalScope())
@@ -424,48 +546,205 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 var index = Array.IndexOf(colors, m_TexturePainter.BrushColor);
                 m_TexturePainter.BrushColor = colors[GUILayout.Toolbar(index, texts)];
             }
+        }
 
-            EditorGUILayout.Space();
+        private void DrawGradientSettings()
+        {
+            DrawColorChannels();
+            m_GradientScope = DrawScopePopup(m_GradientScope, "scope-uv-island-under-drag");
+
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                EditorGUILayout.PrefixLabel(CL4EE.Tr("gradient-shape"));
+
+                var shapes = new[] { GradientShape.Line, GradientShape.Band, GradientShape.Radial };
+                var texts = new[]
+                {
+                    CL4EE.Tr("gradient-shape-line"),
+                    CL4EE.Tr("gradient-shape-band"),
+                    CL4EE.Tr("gradient-shape-radial"),
+                };
+                var index = Array.IndexOf(shapes, m_GradientShape);
+                index = Mathf.Max(index, 0);
+                m_GradientShape = shapes[GUILayout.Toolbar(index, texts)];
+            }
+
+            m_GradientStartValue = EditorGUILayout.Slider(
+                new GUIContent(CL4EE.Tr("gradient-start-value"), CL4EE.Tr("gradient-value-tooltip")),
+                m_GradientStartValue,
+                0.0f,
+                1.0f);
+            m_GradientEndValue = EditorGUILayout.Slider(
+                new GUIContent(CL4EE.Tr("gradient-end-value"), CL4EE.Tr("gradient-value-tooltip")),
+                m_GradientEndValue,
+                0.0f,
+                1.0f);
+            m_GradientCurveExponent = EditorGUILayout.Slider(
+                new GUIContent(CL4EE.Tr("gradient-curve"), "Ctrl + Alt + Mouse Wheel"),
+                m_GradientCurveExponent,
+                k_GradientCurveMin,
+                k_GradientCurveMax);
+
+            if (m_GradientShape == GradientShape.Band)
+            {
+                m_GradientWidth = EditorGUILayout.Slider(
+                    new GUIContent(CL4EE.Tr("gradient-width"), "Ctrl + Mouse Wheel"),
+                    m_GradientWidth,
+                    k_GradientWidthMin,
+                    k_GradientWidthMax);
+            }
+
+            if (m_GradientShape == GradientShape.Band ||
+                m_GradientShape == GradientShape.Radial)
+            {
+                m_GradientFeather = EditorGUILayout.Slider(
+                    new GUIContent(CL4EE.Tr("gradient-feather"), "Ctrl + Shift + Mouse Wheel"),
+                    m_GradientFeather,
+                    k_GradientFeatherMin,
+                    k_GradientFeatherMax);
+            }
+
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                if (GUILayout.Button(CL4EE.Tr("gradient-curve-linear"), EditorStyles.miniButtonLeft))
+                {
+                    m_GradientCurveExponent = 1.0f;
+                }
+                if (GUILayout.Button(CL4EE.Tr("gradient-curve-smooth"), EditorStyles.miniButtonMid))
+                {
+                    m_GradientCurveExponent = 2.0f;
+                }
+                if (GUILayout.Button(CL4EE.Tr("gradient-curve-sharp"), EditorStyles.miniButtonRight))
+                {
+                    m_GradientCurveExponent = 4.0f;
+                }
+            }
+
+            if (GUILayout.Button(CL4EE.Tr("gradient-reverse"), Styles.Button))
+            {
+                (m_GradientStartValue, m_GradientEndValue) = (m_GradientEndValue, m_GradientStartValue);
+            }
+
+            EditorGUILayout.HelpBox(
+                m_GradientScope == OperationScope.UvIslandUnderCursor
+                    ? CL4EE.Tr("gradient-drag-island-hint")
+                    : CL4EE.Tr("gradient-global-hint"),
+                MessageType.Info);
+        }
+
+        private void DrawTextureOperations()
+        {
+            EditorGUILayout.LabelField(CL4EE.Tr("texture-operations"), EditorStyles.boldLabel);
 
             using (new EditorGUILayout.HorizontalScope())
             {
                 if (GUILayout.Button(CL4EE.Tr("fill-black"), Styles.Button))
                 {
+                    CancelActiveOperation();
                     m_TexturePainter.Fill(Color.black);
                     m_TextureUndoStack.Record();
                 }
                 if (GUILayout.Button(CL4EE.Tr("fill-white"), Styles.Button))
                 {
+                    CancelActiveOperation();
                     m_TexturePainter.Fill(Color.white);
-                    m_TextureUndoStack.Record();
-                }
-                if (GUILayout.Button(CL4EE.Tr("inverse"), Styles.Button))
-                {
-                    m_TexturePainter.Inverse();
                     m_TextureUndoStack.Record();
                 }
             }
 
-            if (GUILayout.Button(CL4EE.Tr("reset-view"), Styles.Button))
+            if (GUILayout.Button(CL4EE.Tr("inverse"), Styles.Button))
+            {
+                CancelActiveOperation();
+                m_TexturePainter.Inverse();
+                m_TextureUndoStack.Record();
+            }
+        }
+
+        private void DrawCanvasToolbar()
+        {
+            var canvasWidth = position.width > position.height
+                ? position.width - k_SidebarWidth
+                : position.width;
+            if (canvasWidth < k_CanvasToolbarCompactWidth)
+            {
+                using (new EditorGUILayout.HorizontalScope(Styles.CanvasToolbar))
+                {
+                    DrawViewControls();
+                    GUILayout.FlexibleSpace();
+                }
+                using (new EditorGUILayout.HorizontalScope(Styles.CanvasToolbar))
+                {
+                    DrawPreviewControls();
+                    GUILayout.FlexibleSpace();
+                }
+                return;
+            }
+
+            using (new EditorGUILayout.HorizontalScope(Styles.CanvasToolbar))
+            {
+                DrawViewControls();
+                GUILayout.Space(12.0f);
+                DrawPreviewControls();
+                GUILayout.FlexibleSpace();
+            }
+        }
+
+        private void DrawViewControls()
+        {
+            if (GUILayout.Button(new GUIContent(CL4EE.Tr("reset-view-short"), CL4EE.Tr("reset-view")), EditorStyles.toolbarButton, GUILayout.Width(42.0f)))
             {
                 m_RequestResetView = true;
             }
 
-            if (GUILayout.Button(CL4EE.Tr("save"), Styles.LargeButton))
+            GUILayout.Label(new GUIContent(CL4EE.Tr("zoom"), CL4EE.Tr("view-scale")), GUILayout.Width(40.0f));
+            using (var check = new EditorGUI.ChangeCheckScope())
             {
-                SaveChanges();
+                var prev = m_ViewScale;
+                m_ViewScale = GUILayout.HorizontalSlider(
+                    m_ViewScale,
+                    k_ViewScaleMin,
+                    k_ViewScaleMax,
+                    GUILayout.Width(110.0f));
+                if (check.changed)
+                {
+                    m_ViewPosition -= m_ViewPosition * (1.0f - m_ViewScale / prev);
+                }
             }
+            GUILayout.Label($"{m_ViewScale * 100.0f:0}%", GUILayout.Width(42.0f));
 
-            if (expand)
-            {
-                GUILayout.FlexibleSpace();
-            }
-            else
-            {
-                EditorGUILayout.Space();
-            }
+            GUILayout.Space(10.0f);
+            GUILayout.Label(CL4EE.Tr("mask-opacity"), GUILayout.Width(92.0f));
+            m_ViewOpacity = GUILayout.HorizontalSlider(
+                m_ViewOpacity,
+                k_ViewOpacityMin,
+                k_ViewOpacityMax,
+                GUILayout.Width(110.0f));
+        }
 
-            CL4EE.DrawLanguagePicker();
+        private void DrawPreviewControls()
+        {
+            m_ShowUvPreview = GUILayout.Toggle(
+                m_ShowUvPreview,
+                CL4EE.Tr("uv-preview-short"),
+                EditorStyles.toolbarButton,
+                GUILayout.Width(36.0f));
+            GUILayout.Space(4.0f);
+            m_ShowNormalOverlay = GUILayout.Toggle(
+                m_ShowNormalOverlay,
+                CL4EE.Tr("normal-overlay-short"),
+                EditorStyles.toolbarButton,
+                GUILayout.Width(70.0f));
+
+            GUILayout.Space(10.0f);
+            using (new EditorGUI.DisabledScope(!m_ShowNormalOverlay))
+            {
+                GUILayout.Label(CL4EE.Tr("normal-opacity-short"), GUILayout.Width(102.0f));
+                m_NormalOverlayOpacity = GUILayout.HorizontalSlider(
+                    m_NormalOverlayOpacity,
+                    0.0f,
+                    1.0f,
+                    GUILayout.Width(90.0f));
+            }
         }
 
         private void DrawContents(Rect rect, bool brush)
@@ -476,10 +755,21 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 Vector2Int.RoundToInt(m_TexturePainter.TextureSize),
                 m_ShowUvPreview,
                 m_ShowNormalOverlay,
-                m_NormalOverlayOpacity);
+                m_NormalOverlayOpacity,
+                m_UvMapDrawer.HasActiveIsland && (m_IsPaintingStroke || m_IsGradientDragging));
 
             GUI.color = new(1.0f, 1.0f, 1.0f, m_ViewOpacity);
-            m_TexturePainter.Draw(rect, brush);
+            m_TexturePainter.Draw(rect, brush && m_ToolMode == ToolMode.Paint);
+
+            if (m_IsGradientDragging)
+            {
+                var start = Rect.NormalizedToPoint(rect, new(m_GradientStart.x, 1.0f - m_GradientStart.y));
+                var end = Rect.NormalizedToPoint(rect, new(m_GradientEnd.x, 1.0f - m_GradientEnd.y));
+                Handles.color = Color.cyan;
+                Handles.DrawAAPolyLine(3.0f, start, end);
+                Handles.DrawSolidDisc(start, Vector3.forward, 4.0f);
+                Handles.DrawWireDisc(end, Vector3.forward, 6.0f);
+            }
         }
 
         private void HandleEvents(Rect rect)
@@ -515,11 +805,42 @@ namespace net.nekobako.MaskTextureEditor.Editor
 
                         if (Events.Paint)
                         {
-                            // Paint the texture
                             var pos = Event.current.mousePosition - rect.center + m_ViewPosition;
-                            GetUvTriangles(out var points, out var indices);
-                            m_TexturePainter.BeginStroke(pos / m_ViewScale, points, indices);
-                            m_IsPaintingStroke = true;
+                            var texturePosition = pos / m_ViewScale;
+                            var uv = TexturePositionToUv(texturePosition);
+                            if (m_ToolMode == ToolMode.Gradient)
+                            {
+                                if (!BeginOperationScope(m_GradientScope, uv))
+                                {
+                                    GUIUtility.hotControl = 0;
+                                    Repaint();
+                                    break;
+                                }
+
+                                m_GradientStart = uv;
+                                m_GradientEnd = m_GradientStart;
+                                m_GradientModified = false;
+                                m_IsGradientDragging = true;
+                                m_TexturePainter.BeginGradient();
+                            }
+                            else
+                            {
+                                if (!BeginOperationScope(m_PaintScope, uv))
+                                {
+                                    GUIUtility.hotControl = 0;
+                                    Repaint();
+                                    break;
+                                }
+
+                                // Paint the texture
+                                GetUvTriangles(out var points, out var indices);
+                                m_TexturePainter.BeginStroke(
+                                    texturePosition,
+                                    points,
+                                    indices,
+                                    GetActiveIslandMask());
+                                m_IsPaintingStroke = true;
+                            }
                         }
                         Repaint();
                         break;
@@ -536,6 +857,21 @@ namespace net.nekobako.MaskTextureEditor.Editor
                                 m_TextureUndoStack.Record();
                             }
                             m_IsPaintingStroke = false;
+                            m_UvMapDrawer.ClearActiveIsland();
+                        }
+                        else if (m_IsGradientDragging)
+                        {
+                            if (m_GradientModified && m_TexturePainter.CommitGradient())
+                            {
+                                m_TextureUndoStack.Record();
+                            }
+                            else
+                            {
+                                m_TexturePainter.CancelGradient();
+                            }
+                            m_IsGradientDragging = false;
+                            m_GradientModified = false;
+                            m_UvMapDrawer.ClearActiveIsland();
                         }
                         Repaint();
                         break;
@@ -548,7 +884,26 @@ namespace net.nekobako.MaskTextureEditor.Editor
                             // Paint the texture
                             var pos = Event.current.mousePosition - rect.center + m_ViewPosition;
                             GetUvTriangles(out var points, out var indices);
-                            m_TexturePainter.ContinueStroke(pos / m_ViewScale, points, indices);
+                            m_TexturePainter.ContinueStroke(
+                                pos / m_ViewScale,
+                                points,
+                                indices,
+                                GetActiveIslandMask());
+                        }
+                        else if (m_IsGradientDragging)
+                        {
+                            var pos = Event.current.mousePosition - rect.center + m_ViewPosition;
+                            m_GradientEnd = TexturePositionToUv(pos / m_ViewScale);
+                            m_GradientModified = m_TexturePainter.UpdateGradient(
+                                m_GradientStart,
+                                m_GradientEnd,
+                                m_GradientStartValue,
+                                m_GradientEndValue,
+                                m_GradientCurveExponent,
+                                m_GradientShape,
+                                m_GradientWidth,
+                                m_GradientFeather,
+                                GetActiveIslandMask());
                         }
                         else
                         {
@@ -575,29 +930,49 @@ namespace net.nekobako.MaskTextureEditor.Editor
                             m_ViewOpacity -= delta * k_ViewOpacityFactor;
                             m_ViewOpacity = Mathf.Clamp(m_ViewOpacity, k_ViewOpacityMin, k_ViewOpacityMax);
                         }
-                        else if (Events.BrushSize)
+                        else if (m_ToolMode == ToolMode.Paint && Events.BrushSize)
                         {
                             // Adjust the brush size
                             m_TexturePainter.BrushSize *= 1.0f - delta * k_BrushSizeFactor;
                             m_TexturePainter.BrushSize = Mathf.Clamp(m_TexturePainter.BrushSize, k_BrushSizeMin, k_BrushSizeMax);
                         }
-                        else if (Events.BrushHardness)
+                        else if (m_ToolMode == ToolMode.Paint && Events.BrushHardness)
                         {
                             // Adjust the brush hardness
                             m_TexturePainter.BrushHardness -= delta * k_BrushHardnessFactor;
                             m_TexturePainter.BrushHardness = Mathf.Clamp(m_TexturePainter.BrushHardness, k_BrushHardnessMin, k_BrushHardnessMax);
                         }
-                        else if (Events.BrushStrength)
+                        else if (m_ToolMode == ToolMode.Paint && Events.BrushStrength)
                         {
                             // Adjust the brush strength
                             m_TexturePainter.BrushStrength -= delta * k_BrushStrengthFactor;
                             m_TexturePainter.BrushStrength = Mathf.Clamp(m_TexturePainter.BrushStrength, k_BrushStrengthMin, k_BrushStrengthMax);
                         }
-                        else if (Events.BrushDensity)
+                        else if (m_ToolMode == ToolMode.Paint && Events.BrushDensity)
                         {
                             // Adjust the brush density
                             m_TexturePainter.BrushDensity *= 1.0f - delta * k_BrushDensityFactor;
                             m_TexturePainter.BrushDensity = Mathf.Clamp(m_TexturePainter.BrushDensity, k_BrushDensityMin, k_BrushDensityMax);
+                        }
+                        else if (m_ToolMode == ToolMode.Gradient && m_GradientShape == GradientShape.Band && Events.GradientWidth)
+                        {
+                            // Adjust the gradient band width
+                            m_GradientWidth *= 1.0f - delta * k_GradientWidthFactor;
+                            m_GradientWidth = Mathf.Clamp(m_GradientWidth, k_GradientWidthMin, k_GradientWidthMax);
+                        }
+                        else if (m_ToolMode == ToolMode.Gradient && Events.GradientCurve)
+                        {
+                            // Adjust the gradient curve
+                            m_GradientCurveExponent *= 1.0f - delta * k_GradientCurveFactor;
+                            m_GradientCurveExponent = Mathf.Clamp(m_GradientCurveExponent, k_GradientCurveMin, k_GradientCurveMax);
+                        }
+                        else if (m_ToolMode == ToolMode.Gradient &&
+                            (m_GradientShape == GradientShape.Band || m_GradientShape == GradientShape.Radial) &&
+                            Events.GradientFeather)
+                        {
+                            // Adjust the gradient feather
+                            m_GradientFeather = Mathf.Max(1.0f, m_GradientFeather) * (1.0f - delta * k_GradientFeatherFactor);
+                            m_GradientFeather = Mathf.Clamp(m_GradientFeather, k_GradientFeatherMin, k_GradientFeatherMax);
                         }
                         else
                         {
@@ -611,6 +986,14 @@ namespace net.nekobako.MaskTextureEditor.Editor
                         Repaint();
                         break;
                     }
+                case EventType.KeyDown when Event.current.keyCode == KeyCode.Escape:
+                    {
+                        CancelActiveOperation();
+                        GUIUtility.hotControl = 0;
+                        Event.current.Use();
+                        Repaint();
+                        break;
+                    }
                 case EventType.ValidateCommand:
                     {
                         Repaint();
@@ -620,6 +1003,55 @@ namespace net.nekobako.MaskTextureEditor.Editor
 
             // Ensure non-negative position to avoid scrollbars flickering
             m_ViewPosition = Vector2.Max(m_ViewPosition, Vector2.zero);
+        }
+
+        private Vector2 TexturePositionToUv(Vector2 position)
+        {
+            var textureSize = m_TexturePainter.TextureSize;
+            return new(
+                position.x / textureSize.x,
+                1.0f - position.y / textureSize.y);
+        }
+
+        private bool BeginOperationScope(OperationScope scope, Vector2 uv)
+        {
+            if (scope == OperationScope.WholeTexture)
+            {
+                m_UvMapDrawer.ClearActiveIsland();
+                return true;
+            }
+
+            if (m_UvMapDrawer.TryFindIsland(uv, out var island))
+            {
+                m_UvMapDrawer.SetActiveIsland(island);
+                return true;
+            }
+
+            m_UvMapDrawer.ClearActiveIsland();
+            ShowNotification(new GUIContent(CL4EE.Tr("uv-island-not-found")));
+            return false;
+        }
+
+        private Texture? GetActiveIslandMask()
+        {
+            if (!m_UvMapDrawer.HasActiveIsland)
+            {
+                return null;
+            }
+
+            var textureSize = Vector2Int.RoundToInt(m_TexturePainter.TextureSize);
+            return m_UvMapDrawer.TryGetSelectionMask(textureSize, out var selectionMask)
+                ? selectionMask
+                : null;
+        }
+
+        private void CancelActiveOperation()
+        {
+            m_IsPaintingStroke = false;
+            m_IsGradientDragging = false;
+            m_GradientModified = false;
+            m_TexturePainter.CancelGradient();
+            m_UvMapDrawer.ClearActiveIsland();
         }
 
         private void GetUvTriangles(out Vector2[]? points, out int[]? indices)
@@ -638,6 +1070,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
 
         public override void SaveChanges()
         {
+            CancelActiveOperation();
             base.SaveChanges();
 
             var path = AssetDatabase.GetAssetPath(m_Texture);

--- a/Packages/net.nekobako.mask-texture-editor/Editor/Window.cs
+++ b/Packages/net.nekobako.mask-texture-editor/Editor/Window.cs
@@ -15,8 +15,8 @@ namespace net.nekobako.MaskTextureEditor.Editor
     {
         private enum ToolMode
         {
-            Paint = 0,
-            Gradient = 2,
+            Paint,
+            Gradient,
         }
 
         private enum OperationScope
@@ -68,7 +68,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
         private const float k_ViewOpacityMin = 0.0f;
         private const float k_ViewOpacityMax = 1.0f;
         private const float k_ViewOpacityFactor = 0.01f;
-        private const float k_BrushSizeMin = 10.0f;
+        private const float k_BrushSizeMin = 1.0f;
         private const float k_BrushSizeMax = 1000.0f;
         private const float k_BrushSizeFactor = 0.1f;
         private const float k_BrushHardnessMin = 0.0f;
@@ -87,8 +87,8 @@ namespace net.nekobako.MaskTextureEditor.Editor
         private const float k_GradientWidthMax = 512.0f;
         private const float k_GradientWidthFactor = 0.1f;
         private const float k_GradientFeatherMin = 0.0f;
-        private const float k_GradientFeatherMax = 512.0f;
-        private const float k_GradientFeatherFactor = 0.1f;
+        private const float k_GradientFeatherMax = 2.0f;
+        private const float k_GradientFeatherFactor = 0.01f;
         private const float k_SidebarWidth = 320.0f;
         private const float k_CanvasToolbarCompactWidth = 800.0f;
 
@@ -126,7 +126,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
         private bool m_ShowUvPreview = true;
 
         [SerializeField]
-        private bool m_ShowNormalOverlay = true;
+        private bool m_ShowNormalOverlay = false;
 
         [SerializeField]
         private float m_NormalOverlayOpacity = 0.35f;
@@ -156,7 +156,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
         private float m_GradientWidth = 128.0f;
 
         [SerializeField]
-        private float m_GradientFeather = 32.0f;
+        private float m_GradientFeather = 0.2f;
 
         [SerializeField]
         private Vector2 m_SidebarScrollPosition = Vector2.zero;
@@ -691,7 +691,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
 
         private void DrawViewControls()
         {
-            if (GUILayout.Button(new GUIContent(CL4EE.Tr("reset-view-short"), CL4EE.Tr("reset-view")), EditorStyles.toolbarButton, GUILayout.Width(42.0f)))
+            if (GUILayout.Button(new GUIContent(CL4EE.Tr("reset-view-short"), CL4EE.Tr("reset-view")), EditorStyles.toolbarButton, GUILayout.Width(144.0f)))
             {
                 m_RequestResetView = true;
             }
@@ -727,7 +727,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 m_ShowUvPreview,
                 CL4EE.Tr("uv-preview-short"),
                 EditorStyles.toolbarButton,
-                GUILayout.Width(36.0f));
+                GUILayout.Width(70.0f));
             GUILayout.Space(4.0f);
             m_ShowNormalOverlay = GUILayout.Toggle(
                 m_ShowNormalOverlay,
@@ -761,6 +761,14 @@ namespace net.nekobako.MaskTextureEditor.Editor
             GUI.color = new(1.0f, 1.0f, 1.0f, m_ViewOpacity);
             m_TexturePainter.Draw(rect, brush && m_ToolMode == ToolMode.Paint);
 
+            if (m_ToolMode == ToolMode.Gradient)
+            {
+                DrawGradientPreview(rect, brush);
+            }
+        }
+
+        private void DrawGradientPreview(Rect rect, bool hover)
+        {
             if (m_IsGradientDragging)
             {
                 var start = Rect.NormalizedToPoint(rect, new(m_GradientStart.x, 1.0f - m_GradientStart.y));
@@ -769,6 +777,86 @@ namespace net.nekobako.MaskTextureEditor.Editor
                 Handles.DrawAAPolyLine(3.0f, start, end);
                 Handles.DrawSolidDisc(start, Vector3.forward, 4.0f);
                 Handles.DrawWireDisc(end, Vector3.forward, 6.0f);
+
+                switch (m_GradientShape)
+                {
+                    case GradientShape.Band:
+                        DrawBandPreview(start, end);
+                        break;
+                    case GradientShape.Radial:
+                        DrawRadialPreview(start, end);
+                        break;
+                }
+                return;
+            }
+
+            if (hover && m_GradientShape == GradientShape.Band)
+            {
+                DrawBandHoverPreview(Event.current.mousePosition);
+            }
+        }
+
+        private void DrawBandPreview(Vector2 start, Vector2 end)
+        {
+            var direction = end - start;
+            if (direction.sqrMagnitude <= Mathf.Epsilon)
+            {
+                return;
+            }
+
+            var normal = Vector2.Perpendicular(direction).normalized;
+            var halfWidth = m_GradientWidth * m_ViewScale * 0.5f;
+            var outerHalfWidth = halfWidth * (1.0f + m_GradientFeather);
+
+            DrawOffsetSegment(start, end, normal, halfWidth, new(0.0f, 1.0f, 1.0f, 0.9f), false);
+            DrawOffsetSegment(start, end, normal, -halfWidth, new(0.0f, 1.0f, 1.0f, 0.9f), false);
+
+            if (outerHalfWidth > halfWidth)
+            {
+                DrawOffsetSegment(start, end, normal, outerHalfWidth, new(0.0f, 1.0f, 1.0f, 0.45f), true);
+                DrawOffsetSegment(start, end, normal, -outerHalfWidth, new(0.0f, 1.0f, 1.0f, 0.45f), true);
+            }
+        }
+
+        private void DrawBandHoverPreview(Vector2 center)
+        {
+            var halfWidth = m_GradientWidth * m_ViewScale * 0.5f;
+            var outerHalfWidth = halfWidth * (1.0f + m_GradientFeather);
+
+            Handles.color = new(0.0f, 1.0f, 1.0f, 0.9f);
+            Handles.DrawWireDisc(center, Vector3.forward, halfWidth);
+
+            if (outerHalfWidth > halfWidth)
+            {
+                Handles.color = new(0.0f, 1.0f, 1.0f, 0.45f);
+                Handles.DrawWireDisc(center, Vector3.forward, outerHalfWidth);
+            }
+        }
+
+        private void DrawRadialPreview(Vector2 start, Vector2 end)
+        {
+            var radius = (end - start).magnitude;
+            Handles.color = new(0.0f, 1.0f, 1.0f, 0.65f);
+            Handles.DrawWireDisc(start, Vector3.forward, radius);
+            if (m_GradientFeather > 0.0f)
+            {
+                Handles.color = new(0.0f, 1.0f, 1.0f, 0.35f);
+                Handles.DrawWireDisc(start, Vector3.forward, radius * (1.0f + m_GradientFeather));
+            }
+        }
+
+        private static void DrawOffsetSegment(Vector2 start, Vector2 end, Vector2 normal, float offset, Color color, bool dotted)
+        {
+            var a = start + normal * offset;
+            var b = end + normal * offset;
+            Handles.color = color;
+            if (dotted)
+            {
+                Handles.DrawDottedLine(a, b, 4.0f);
+            }
+            else
+            {
+                Handles.DrawAAPolyLine(2.0f, a, b);
             }
         }
 
@@ -971,7 +1059,7 @@ namespace net.nekobako.MaskTextureEditor.Editor
                             Events.GradientFeather)
                         {
                             // Adjust the gradient feather
-                            m_GradientFeather = Mathf.Max(1.0f, m_GradientFeather) * (1.0f - delta * k_GradientFeatherFactor);
+                            m_GradientFeather -= delta * k_GradientFeatherFactor;
                             m_GradientFeather = Mathf.Clamp(m_GradientFeather, k_GradientFeatherMin, k_GradientFeatherMax);
                         }
                         else

--- a/Packages/net.nekobako.mask-texture-editor/Localization/en-us.po
+++ b/Packages/net.nekobako.mask-texture-editor/Localization/en-us.po
@@ -44,8 +44,125 @@ msgstr "Normals"
 msgid "normal-overlay-opacity"
 msgstr "Normal Opacity"
 
+msgid "tool-mode"
+msgstr "Tool"
+
+msgid "tool-mode-paint"
+msgstr "Paint"
+
+msgid "tool-mode-select-island"
+msgstr "UV Selection"
+
+msgid "tool-mode-gradient"
+msgstr "Gradient"
+
+msgid "clear-island-selection"
+msgstr "Clear Island Selection"
+
+msgid "selection"
+msgstr "Selection"
+
+msgid "selection-mask"
+msgstr "Selection Mask"
+
+msgid "selection-scope"
+msgstr "Scope"
+
+msgid "selection-whole-texture"
+msgstr "Whole Texture"
+
+msgid "selection-uv-island"
+msgstr "UV Island"
+
+msgid "select-uv-island"
+msgstr "Select UV Island"
+
+msgid "select-uv-island-active"
+msgstr "Click UV Island..."
+
+msgid "show-selection-overlay"
+msgstr "Show Overlay"
+
+msgid "clear"
+msgstr "Clear"
+
+msgid "island-selected"
+msgstr "The selected UV island now limits every paint and texture operation."
+
+msgid "island-select-hint"
+msgstr "Click a face to use its UV island as the global editing selection."
+
+msgid "gradient-start-value"
+msgstr "Start Value"
+
+msgid "gradient-end-value"
+msgstr "End Value"
+
+msgid "gradient-value-tooltip"
+msgstr "Blend strength baked into the source mask"
+
+msgid "gradient-curve"
+msgstr "Curve"
+
+msgid "gradient-curve-linear"
+msgstr "Linear"
+
+msgid "gradient-curve-smooth"
+msgstr "Smooth"
+
+msgid "gradient-curve-sharp"
+msgstr "Sharp"
+
+msgid "gradient-reverse"
+msgstr "Reverse Gradient"
+
+msgid "gradient-drag-hint"
+msgstr "Drag in the canvas to apply a gradient inside the selected island."
+
+msgid "gradient-selection-required"
+msgstr "Select an UV island before using the gradient tool."
+
+msgid "gradient-global-hint"
+msgstr "Drag in the canvas to apply a gradient to the whole texture."
+
+msgid "scope"
+msgstr "Scope"
+
+msgid "scope-whole-texture"
+msgstr "Whole Texture"
+
+msgid "scope-uv-island-under-brush"
+msgstr "UV Island Under Brush"
+
+msgid "scope-uv-island-under-drag"
+msgstr "UV Island Under Drag"
+
+msgid "gradient-shape"
+msgstr "Shape"
+
+msgid "gradient-shape-line"
+msgstr "Line"
+
+msgid "gradient-shape-band"
+msgstr "Band"
+
+msgid "gradient-shape-radial"
+msgstr "Radial"
+
+msgid "gradient-width"
+msgstr "Width"
+
+msgid "gradient-feather"
+msgstr "Feather"
+
+msgid "gradient-drag-island-hint"
+msgstr "Drag in the canvas. The UV island under the drag start limits this operation."
+
+msgid "uv-island-not-found"
+msgstr "No UV island found under the cursor."
+
 msgid "brush-size"
-msgstr "Brush Size (Ctrl)"
+msgstr "Size"
 
 msgid "brush-mode"
 msgstr "Brush Mode"
@@ -57,13 +174,13 @@ msgid "brush-mode-triangle"
 msgstr "Face"
 
 msgid "brush-hardness"
-msgstr "Brush Hardness (Ctrl + Alt)"
+msgstr "Hardness"
 
 msgid "brush-strength"
-msgstr "Brush Strength (Ctrl + Shift)"
+msgstr "Strength"
 
 msgid "brush-density"
-msgstr "Brush Density (Ctrl + Alt + Shift)"
+msgstr "Density"
 
 msgid "brush-color"
 msgstr "Brush Color"
@@ -82,6 +199,27 @@ msgstr "Fill White"
 
 msgid "inverse"
 msgstr "Inverse Color"
+
+msgid "texture-operations"
+msgstr "Texture Operations"
+
+msgid "reset-view-short"
+msgstr "Fit"
+
+msgid "zoom"
+msgstr "Zoom"
+
+msgid "mask-opacity"
+msgstr "Mask Opacity"
+
+msgid "uv-preview-short"
+msgstr "UV"
+
+msgid "normal-overlay-short"
+msgstr "Normals"
+
+msgid "normal-opacity-short"
+msgstr "Normal Opacity"
 
 msgid "reset-view"
 msgstr "Fit the view to the window"

--- a/Packages/net.nekobako.mask-texture-editor/Localization/en-us.po
+++ b/Packages/net.nekobako.mask-texture-editor/Localization/en-us.po
@@ -35,6 +35,15 @@ msgstr "View Opacity (Shift)"
 msgid "brush-size"
 msgstr "Brush Size (Ctrl)"
 
+msgid "brush-mode"
+msgstr "Brush Mode"
+
+msgid "brush-mode-circle"
+msgstr "Circle"
+
+msgid "brush-mode-triangle"
+msgstr "Face"
+
 msgid "brush-hardness"
 msgstr "Brush Hardness (Ctrl + Alt)"
 

--- a/Packages/net.nekobako.mask-texture-editor/Localization/en-us.po
+++ b/Packages/net.nekobako.mask-texture-editor/Localization/en-us.po
@@ -29,68 +29,14 @@ msgstr "Material Slot"
 msgid "view-scale"
 msgstr "View Scale"
 
-msgid "view-opacity"
-msgstr "View Opacity (Shift)"
-
-msgid "preview-layers"
-msgstr "Preview Layers"
-
-msgid "uv-preview"
-msgstr "UV Wireframe"
-
-msgid "normal-overlay"
-msgstr "Normals"
-
-msgid "normal-overlay-opacity"
-msgstr "Normal Opacity"
-
 msgid "tool-mode"
 msgstr "Tool"
 
 msgid "tool-mode-paint"
 msgstr "Paint"
 
-msgid "tool-mode-select-island"
-msgstr "UV Selection"
-
 msgid "tool-mode-gradient"
 msgstr "Gradient"
-
-msgid "clear-island-selection"
-msgstr "Clear Island Selection"
-
-msgid "selection"
-msgstr "Selection"
-
-msgid "selection-mask"
-msgstr "Selection Mask"
-
-msgid "selection-scope"
-msgstr "Scope"
-
-msgid "selection-whole-texture"
-msgstr "Whole Texture"
-
-msgid "selection-uv-island"
-msgstr "UV Island"
-
-msgid "select-uv-island"
-msgstr "Select UV Island"
-
-msgid "select-uv-island-active"
-msgstr "Click UV Island..."
-
-msgid "show-selection-overlay"
-msgstr "Show Overlay"
-
-msgid "clear"
-msgstr "Clear"
-
-msgid "island-selected"
-msgstr "The selected UV island now limits every paint and texture operation."
-
-msgid "island-select-hint"
-msgstr "Click a face to use its UV island as the global editing selection."
 
 msgid "gradient-start-value"
 msgstr "Start Value"
@@ -115,12 +61,6 @@ msgstr "Sharp"
 
 msgid "gradient-reverse"
 msgstr "Reverse Gradient"
-
-msgid "gradient-drag-hint"
-msgstr "Drag in the canvas to apply a gradient inside the selected island."
-
-msgid "gradient-selection-required"
-msgstr "Select an UV island before using the gradient tool."
 
 msgid "gradient-global-hint"
 msgstr "Drag in the canvas to apply a gradient to the whole texture."

--- a/Packages/net.nekobako.mask-texture-editor/Localization/en-us.po
+++ b/Packages/net.nekobako.mask-texture-editor/Localization/en-us.po
@@ -32,6 +32,18 @@ msgstr "View Scale"
 msgid "view-opacity"
 msgstr "View Opacity (Shift)"
 
+msgid "preview-layers"
+msgstr "Preview Layers"
+
+msgid "uv-preview"
+msgstr "UV Wireframe"
+
+msgid "normal-overlay"
+msgstr "Normals"
+
+msgid "normal-overlay-opacity"
+msgstr "Normal Opacity"
+
 msgid "brush-size"
 msgstr "Brush Size (Ctrl)"
 

--- a/Packages/net.nekobako.mask-texture-editor/Localization/ja-jp.po
+++ b/Packages/net.nekobako.mask-texture-editor/Localization/ja-jp.po
@@ -32,6 +32,18 @@ msgstr "表示倍率"
 msgid "view-opacity"
 msgstr "表示透明度 (Shift)"
 
+msgid "preview-layers"
+msgstr "プレビューレイヤー"
+
+msgid "uv-preview"
+msgstr "UV ワイヤーフレーム"
+
+msgid "normal-overlay"
+msgstr "法線"
+
+msgid "normal-overlay-opacity"
+msgstr "法線の不透明度"
+
 msgid "brush-size"
 msgstr "ブラシサイズ (Ctrl)"
 

--- a/Packages/net.nekobako.mask-texture-editor/Localization/ja-jp.po
+++ b/Packages/net.nekobako.mask-texture-editor/Localization/ja-jp.po
@@ -44,8 +44,125 @@ msgstr "法線"
 msgid "normal-overlay-opacity"
 msgstr "法線の不透明度"
 
+msgid "tool-mode"
+msgstr "ツール"
+
+msgid "tool-mode-paint"
+msgstr "描画"
+
+msgid "tool-mode-select-island"
+msgstr "UV 選択"
+
+msgid "tool-mode-gradient"
+msgstr "グラデーション"
+
+msgid "clear-island-selection"
+msgstr "UV アイランド選択を解除"
+
+msgid "selection"
+msgstr "選択範囲"
+
+msgid "selection-mask"
+msgstr "選択マスク"
+
+msgid "selection-scope"
+msgstr "適用範囲"
+
+msgid "selection-whole-texture"
+msgstr "テクスチャ全体"
+
+msgid "selection-uv-island"
+msgstr "UV アイランド"
+
+msgid "select-uv-island"
+msgstr "UV アイランドを選択"
+
+msgid "select-uv-island-active"
+msgstr "UV アイランドをクリック..."
+
+msgid "show-selection-overlay"
+msgstr "選択範囲を表示"
+
+msgid "clear"
+msgstr "解除"
+
+msgid "island-selected"
+msgstr "選択した UV アイランドがすべての描画とテクスチャ操作を制限します。"
+
+msgid "island-select-hint"
+msgstr "面をクリックして、その UV アイランドを編集範囲として使用します。"
+
+msgid "gradient-start-value"
+msgstr "開始値"
+
+msgid "gradient-end-value"
+msgstr "終了値"
+
+msgid "gradient-value-tooltip"
+msgstr "元のマスクへ焼き込むブレンド強度"
+
+msgid "gradient-curve"
+msgstr "カーブ"
+
+msgid "gradient-curve-linear"
+msgstr "リニア"
+
+msgid "gradient-curve-smooth"
+msgstr "スムーズ"
+
+msgid "gradient-curve-sharp"
+msgstr "シャープ"
+
+msgid "gradient-reverse"
+msgstr "グラデーションを反転"
+
+msgid "gradient-drag-hint"
+msgstr "キャンバス上でドラッグして、選択したアイランド内にグラデーションを適用します。"
+
+msgid "gradient-selection-required"
+msgstr "グラデーションを使用する前に UV アイランドを選択してください。"
+
+msgid "gradient-global-hint"
+msgstr "キャンバス上でドラッグして、テクスチャ全体にグラデーションを適用します。"
+
+msgid "scope"
+msgstr "適用範囲"
+
+msgid "scope-whole-texture"
+msgstr "テクスチャ全体"
+
+msgid "scope-uv-island-under-brush"
+msgstr "ブラシ下の UV アイランド"
+
+msgid "scope-uv-island-under-drag"
+msgstr "ドラッグ開始位置の UV アイランド"
+
+msgid "gradient-shape"
+msgstr "形状"
+
+msgid "gradient-shape-line"
+msgstr "ライン"
+
+msgid "gradient-shape-band"
+msgstr "帯状"
+
+msgid "gradient-shape-radial"
+msgstr "放射状"
+
+msgid "gradient-width"
+msgstr "幅"
+
+msgid "gradient-feather"
+msgstr "フェザー"
+
+msgid "gradient-drag-island-hint"
+msgstr "キャンバス上でドラッグします。ドラッグ開始位置の UV アイランドが今回の操作範囲を制限します。"
+
+msgid "uv-island-not-found"
+msgstr "カーソル下に UV アイランドが見つかりません。"
+
 msgid "brush-size"
-msgstr "ブラシサイズ (Ctrl)"
+msgstr "サイズ"
 
 msgid "brush-mode"
 msgstr "ブラシモード"
@@ -57,13 +174,13 @@ msgid "brush-mode-triangle"
 msgstr "面"
 
 msgid "brush-hardness"
-msgstr "ブラシ硬度 (Ctrl + Alt)"
+msgstr "硬度"
 
 msgid "brush-strength"
-msgstr "ブラシ強度 (Ctrl + Shift)"
+msgstr "強度"
 
 msgid "brush-density"
-msgstr "ブラシ密度 (Ctrl + Alt + Shift)"
+msgstr "密度"
 
 msgid "brush-color"
 msgstr "ブラシカラー"
@@ -82,6 +199,27 @@ msgstr "白で塗りつぶす"
 
 msgid "inverse"
 msgstr "色を反転させる"
+
+msgid "texture-operations"
+msgstr "テクスチャ操作"
+
+msgid "reset-view-short"
+msgstr "全体"
+
+msgid "zoom"
+msgstr "倍率"
+
+msgid "mask-opacity"
+msgstr "マスク不透明度"
+
+msgid "uv-preview-short"
+msgstr "UV"
+
+msgid "normal-overlay-short"
+msgstr "法線"
+
+msgid "normal-opacity-short"
+msgstr "法線不透明度"
 
 msgid "reset-view"
 msgstr "表示をウィンドウに合わせる"

--- a/Packages/net.nekobako.mask-texture-editor/Localization/ja-jp.po
+++ b/Packages/net.nekobako.mask-texture-editor/Localization/ja-jp.po
@@ -35,6 +35,15 @@ msgstr "表示透明度 (Shift)"
 msgid "brush-size"
 msgstr "ブラシサイズ (Ctrl)"
 
+msgid "brush-mode"
+msgstr "ブラシモード"
+
+msgid "brush-mode-circle"
+msgstr "円形"
+
+msgid "brush-mode-triangle"
+msgstr "面"
+
 msgid "brush-hardness"
 msgstr "ブラシ硬度 (Ctrl + Alt)"
 

--- a/Packages/net.nekobako.mask-texture-editor/Localization/ja-jp.po
+++ b/Packages/net.nekobako.mask-texture-editor/Localization/ja-jp.po
@@ -29,68 +29,14 @@ msgstr "マテリアルスロット"
 msgid "view-scale"
 msgstr "表示倍率"
 
-msgid "view-opacity"
-msgstr "表示透明度 (Shift)"
-
-msgid "preview-layers"
-msgstr "プレビューレイヤー"
-
-msgid "uv-preview"
-msgstr "UV ワイヤーフレーム"
-
-msgid "normal-overlay"
-msgstr "法線"
-
-msgid "normal-overlay-opacity"
-msgstr "法線の不透明度"
-
 msgid "tool-mode"
 msgstr "ツール"
 
 msgid "tool-mode-paint"
 msgstr "描画"
 
-msgid "tool-mode-select-island"
-msgstr "UV 選択"
-
 msgid "tool-mode-gradient"
 msgstr "グラデーション"
-
-msgid "clear-island-selection"
-msgstr "UV アイランド選択を解除"
-
-msgid "selection"
-msgstr "選択範囲"
-
-msgid "selection-mask"
-msgstr "選択マスク"
-
-msgid "selection-scope"
-msgstr "適用範囲"
-
-msgid "selection-whole-texture"
-msgstr "テクスチャ全体"
-
-msgid "selection-uv-island"
-msgstr "UV アイランド"
-
-msgid "select-uv-island"
-msgstr "UV アイランドを選択"
-
-msgid "select-uv-island-active"
-msgstr "UV アイランドをクリック..."
-
-msgid "show-selection-overlay"
-msgstr "選択範囲を表示"
-
-msgid "clear"
-msgstr "解除"
-
-msgid "island-selected"
-msgstr "選択した UV アイランドがすべての描画とテクスチャ操作を制限します。"
-
-msgid "island-select-hint"
-msgstr "面をクリックして、その UV アイランドを編集範囲として使用します。"
 
 msgid "gradient-start-value"
 msgstr "開始値"
@@ -115,12 +61,6 @@ msgstr "シャープ"
 
 msgid "gradient-reverse"
 msgstr "グラデーションを反転"
-
-msgid "gradient-drag-hint"
-msgstr "キャンバス上でドラッグして、選択したアイランド内にグラデーションを適用します。"
-
-msgid "gradient-selection-required"
-msgstr "グラデーションを使用する前に UV アイランドを選択してください。"
 
 msgid "gradient-global-hint"
 msgstr "キャンバス上でドラッグして、テクスチャ全体にグラデーションを適用します。"

--- a/Packages/net.nekobako.mask-texture-editor/Localization/zh-hant.po
+++ b/Packages/net.nekobako.mask-texture-editor/Localization/zh-hant.po
@@ -32,6 +32,18 @@ msgstr "視圖縮放"
 msgid "view-opacity"
 msgstr "視圖透明度 (Shift)"
 
+msgid "preview-layers"
+msgstr "預覽圖層"
+
+msgid "uv-preview"
+msgstr "UV 線框"
+
+msgid "normal-overlay"
+msgstr "法線"
+
+msgid "normal-overlay-opacity"
+msgstr "法線不透明度"
+
 msgid "brush-size"
 msgstr "筆刷大小 (Ctrl)"
 

--- a/Packages/net.nekobako.mask-texture-editor/Localization/zh-hant.po
+++ b/Packages/net.nekobako.mask-texture-editor/Localization/zh-hant.po
@@ -44,8 +44,125 @@ msgstr "法線"
 msgid "normal-overlay-opacity"
 msgstr "法線不透明度"
 
+msgid "tool-mode"
+msgstr "工具"
+
+msgid "tool-mode-paint"
+msgstr "繪製"
+
+msgid "tool-mode-select-island"
+msgstr "UV 選取"
+
+msgid "tool-mode-gradient"
+msgstr "漸層"
+
+msgid "clear-island-selection"
+msgstr "清除 UV 島選取"
+
+msgid "selection"
+msgstr "選取範圍"
+
+msgid "selection-mask"
+msgstr "選取遮罩"
+
+msgid "selection-scope"
+msgstr "作用範圍"
+
+msgid "selection-whole-texture"
+msgstr "整張貼圖"
+
+msgid "selection-uv-island"
+msgstr "UV 島"
+
+msgid "select-uv-island"
+msgstr "選取 UV 島"
+
+msgid "select-uv-island-active"
+msgstr "點擊 UV 島..."
+
+msgid "show-selection-overlay"
+msgstr "顯示選取覆蓋"
+
+msgid "clear"
+msgstr "清除"
+
+msgid "island-selected"
+msgstr "選取的 UV 島會限制所有繪製與貼圖操作。"
+
+msgid "island-select-hint"
+msgstr "點擊一個面，將其 UV 島設為全域編輯範圍。"
+
+msgid "gradient-start-value"
+msgstr "起始值"
+
+msgid "gradient-end-value"
+msgstr "結束值"
+
+msgid "gradient-value-tooltip"
+msgstr "烘焙到來源 Mask 的混合強度"
+
+msgid "gradient-curve"
+msgstr "曲線"
+
+msgid "gradient-curve-linear"
+msgstr "線性"
+
+msgid "gradient-curve-smooth"
+msgstr "平滑"
+
+msgid "gradient-curve-sharp"
+msgstr "銳利"
+
+msgid "gradient-reverse"
+msgstr "反轉漸層"
+
+msgid "gradient-drag-hint"
+msgstr "在畫布上拖曳，以在選取的 UV 島內套用漸層。"
+
+msgid "gradient-selection-required"
+msgstr "使用漸層工具前請先選取 UV 島。"
+
+msgid "gradient-global-hint"
+msgstr "在畫布上拖曳，以對整張貼圖套用漸層。"
+
+msgid "scope"
+msgstr "作用範圍"
+
+msgid "scope-whole-texture"
+msgstr "整張貼圖"
+
+msgid "scope-uv-island-under-brush"
+msgstr "筆刷下的 UV 島"
+
+msgid "scope-uv-island-under-drag"
+msgstr "拖曳起點的 UV 島"
+
+msgid "gradient-shape"
+msgstr "漸變形狀"
+
+msgid "gradient-shape-line"
+msgstr "線性"
+
+msgid "gradient-shape-band"
+msgstr "帶狀"
+
+msgid "gradient-shape-radial"
+msgstr "放射狀"
+
+msgid "gradient-width"
+msgstr "寬度"
+
+msgid "gradient-feather"
+msgstr "邊緣柔化"
+
+msgid "gradient-drag-island-hint"
+msgstr "在畫布上拖曳。拖曳起點所在的 UV 島會限制本次操作範圍。"
+
+msgid "uv-island-not-found"
+msgstr "游標下方找不到 UV 島。"
+
 msgid "brush-size"
-msgstr "筆刷大小 (Ctrl)"
+msgstr "大小"
 
 msgid "brush-mode"
 msgstr "筆刷模式"
@@ -57,13 +174,13 @@ msgid "brush-mode-triangle"
 msgstr "面"
 
 msgid "brush-hardness"
-msgstr "筆刷硬度 (Ctrl + Alt)"
+msgstr "硬度"
 
 msgid "brush-strength"
-msgstr "筆刷強度 (Ctrl + Shift)"
+msgstr "強度"
 
 msgid "brush-density"
-msgstr "筆刷密度 (Ctrl + Alt + Shift)"
+msgstr "密度"
 
 msgid "brush-color"
 msgstr "筆刷顏色"
@@ -82,6 +199,27 @@ msgstr "填滿白色"
 
 msgid "inverse"
 msgstr "反轉顏色"
+
+msgid "texture-operations"
+msgstr "貼圖操作"
+
+msgid "reset-view-short"
+msgstr "適合"
+
+msgid "zoom"
+msgstr "縮放"
+
+msgid "mask-opacity"
+msgstr "Mask 透明度"
+
+msgid "uv-preview-short"
+msgstr "UV"
+
+msgid "normal-overlay-short"
+msgstr "法線"
+
+msgid "normal-opacity-short"
+msgstr "法線透明度"
 
 msgid "reset-view"
 msgstr "縮放視圖至視窗大小"

--- a/Packages/net.nekobako.mask-texture-editor/Localization/zh-hant.po
+++ b/Packages/net.nekobako.mask-texture-editor/Localization/zh-hant.po
@@ -35,6 +35,15 @@ msgstr "視圖透明度 (Shift)"
 msgid "brush-size"
 msgstr "筆刷大小 (Ctrl)"
 
+msgid "brush-mode"
+msgstr "筆刷模式"
+
+msgid "brush-mode-circle"
+msgstr "圓形"
+
+msgid "brush-mode-triangle"
+msgstr "面"
+
 msgid "brush-hardness"
 msgstr "筆刷硬度 (Ctrl + Alt)"
 

--- a/Packages/net.nekobako.mask-texture-editor/Localization/zh-hant.po
+++ b/Packages/net.nekobako.mask-texture-editor/Localization/zh-hant.po
@@ -29,68 +29,14 @@ msgstr "材質槽"
 msgid "view-scale"
 msgstr "視圖縮放"
 
-msgid "view-opacity"
-msgstr "視圖透明度 (Shift)"
-
-msgid "preview-layers"
-msgstr "預覽圖層"
-
-msgid "uv-preview"
-msgstr "UV 線框"
-
-msgid "normal-overlay"
-msgstr "法線"
-
-msgid "normal-overlay-opacity"
-msgstr "法線不透明度"
-
 msgid "tool-mode"
 msgstr "工具"
 
 msgid "tool-mode-paint"
 msgstr "繪製"
 
-msgid "tool-mode-select-island"
-msgstr "UV 選取"
-
 msgid "tool-mode-gradient"
 msgstr "漸層"
-
-msgid "clear-island-selection"
-msgstr "清除 UV 島選取"
-
-msgid "selection"
-msgstr "選取範圍"
-
-msgid "selection-mask"
-msgstr "選取遮罩"
-
-msgid "selection-scope"
-msgstr "作用範圍"
-
-msgid "selection-whole-texture"
-msgstr "整張貼圖"
-
-msgid "selection-uv-island"
-msgstr "UV 島"
-
-msgid "select-uv-island"
-msgstr "選取 UV 島"
-
-msgid "select-uv-island-active"
-msgstr "點擊 UV 島..."
-
-msgid "show-selection-overlay"
-msgstr "顯示選取覆蓋"
-
-msgid "clear"
-msgstr "清除"
-
-msgid "island-selected"
-msgstr "選取的 UV 島會限制所有繪製與貼圖操作。"
-
-msgid "island-select-hint"
-msgstr "點擊一個面，將其 UV 島設為全域編輯範圍。"
 
 msgid "gradient-start-value"
 msgstr "起始值"
@@ -115,12 +61,6 @@ msgstr "銳利"
 
 msgid "gradient-reverse"
 msgstr "反轉漸層"
-
-msgid "gradient-drag-hint"
-msgstr "在畫布上拖曳，以在選取的 UV 島內套用漸層。"
-
-msgid "gradient-selection-required"
-msgstr "使用漸層工具前請先選取 UV 島。"
 
 msgid "gradient-global-hint"
 msgstr "在畫布上拖曳，以對整張貼圖套用漸層。"


### PR DESCRIPTION
Hi, first of all, thank you for creating Mask Texture Editor.

I really like this tool because it makes simple mask texture editing possible directly inside Unity, without needing to open Photoshop or another external image editor. Being able to reference the UV layout while editing is very convenient, and the existing support for Modular Avatar and Avatar Optimizer also makes the tool very practical to use.

While using it, I felt that the current feature set was still a bit minimal sometimes, so I tried extending the editor with several additional features. This PR adds UV-aware editing tools such as UV island-scoped operations, face/triangle painting, gradient editing, and additional preview overlays. The goal is to make workflows such as editing masks for mesh deletion, or adjusting emission / MatCap masks from materials, easier to complete inside Unity.

**Notes**:

* For validation, I installed the original VPM package through VCC, replaced the contents of `Packages/net.nekobako.mask-texture-editor` with the modified one from this branch, and manually tested the main editing workflows several times. So far, I have not noticed any obvious problems.
* Selection mask support for `Fill` and `Invert` operations has already been implemented in the code, but I am currently not sure how it should be integrated into the GUI. Because of that, these operations are not yet exposed as UV island-scoped GUI actions in this PR.
* Most parts of this implementation were AI-assisted. I reviewed the generated changes at a high level and manually tested the main workflows, but additional review would be appreciated, especially around edge cases.

This is a relatively large PR, so I would be happy to split it into smaller PRs if that would make review easier. Even if this PR is not accepted, I would still be glad if similar features could be considered for future development, as I think they would be very useful.

The main changes are summarized below:

# Changes

## Face / triangle brush mode

Added a new brush mode that paints whole UV triangles/faces.

The face brush:

* Detects UV triangles that intersect the brush area.
* Paints complete hit triangles.
* Avoids repainting the same triangle repeatedly during a single stroke.
* Uses a temporary triangle mask render texture.
* Applies a small amount of triangle padding to reduce visible gaps along UV triangle edges.
* Supports the same color channel mask and brush strength settings as regular painting.

Brush hardness is disabled in face brush mode because the operation is triangle-based rather than soft circular painting.

## UV topology detection

Added UV topology analysis for triangle meshes.

The new topology logic:

* Groups connected UV triangles into UV islands.
* Uses shared UV edges to determine island connectivity.
* Provides lookup support for finding the island under a given UV coordinate.
* Provides triangle lists for generating island selection masks.

This is used by island-constrained operations and selection overlay rendering.

## UV island-aware editing

Added support for limiting texture operations to the UV island under the cursor.

Supported operations currently exposed through the GUI include:

* Brush painting
* Face/triangle painting
* Gradient application

The editor can now generate a selection mask for the active UV island and pass it to the relevant paint and gradient shaders. When no UV island is found under the cursor, the operation is cancelled and the editor shows a notification.

## Gradient tool

Added a new gradient editing mode.

Supported gradient shapes:

* Line
* Band
* Radial

Gradient settings include:

* Start value
* End value
* Curve exponent
* Width, for band gradients
* Feather, for band and radial gradients
* Reverse gradient
* Curve presets: Linear, Smooth, Sharp

The gradient tool uses a preview render texture while dragging. The result is only committed when the drag operation completes successfully.

Gradients can be applied to:

* The whole texture
* The UV island under the drag start position

## Preview layers

Added new preview layer controls to the canvas toolbar.

The editor now supports:

* UV wireframe toggle
* Normal overlay toggle
* Normal overlay opacity

The normal overlay is rendered from mesh normals into a temporary render texture. If vertex normals are unavailable or invalid, face normals are used as a fallback.

The selected UV island overlay is generated from the active island mask and displayed as a semi-transparent cyan overlay.

## Editor UI updates

Reorganized the editor window layout to support the new tools and controls.

Notable UI changes:

* Added tool mode selection for Paint and Gradient.
* Added operation scope controls.
* Added brush mode selection.
* Moved preview controls to a compact canvas toolbar.
* Added scroll support to the side panel.
* Added more compact labels for brush controls.
* Moved shortcut hints from inline labels, such as the hints shown after hardness and other properties, into tooltips that appear on mouse hover.
* Added handling for cancelling active operations when switching tools or closing the window.
* Added Escape key support to cancel the active Gradient operation.

<img width="538" height="311" alt="2026-06-17 180132" src="https://github.com/user-attachments/assets/d8e4a2d7-ea20-4eeb-a1ba-6dd4ca5037e0" />
<img width="536" height="310" alt="2026-06-17 180141" src="https://github.com/user-attachments/assets/f550274b-b0af-4dfa-a6e5-594776cf723f" />

## Shader updates

Added new shaders:

* `Gradient.shader`
* `TrianglePaint.shader`
* `NormalOverlay.shader`
* `SelectionOverlay.shader`

Updated existing shaders:

* `Paint.shader`
* `Fill.shader`
* `Inverse.shader`

The updated shaders now support selection masks, so operations can be constrained to a selected UV island where applicable.

## Undo behavior

Updated texture undo handling to use complete object undo registration.

This change was added because I encountered an undo issue similar to issue #5. The new handling appears to improve the behavior in some cases, and the editor window is now repainted after undo/redo so the displayed texture state updates immediately.

However, the undo issue does not seem to be completely resolved yet. There may still be cases where undo does not behave correctly, so this part may need further investigation.

## Localization

Updated localization strings for:

* English
* Japanese
* Traditional Chinese

New strings cover:

* Tool modes
* Brush modes
* Gradient controls
* Preview layers
* UV island scopes
* Selection overlay
* Error/notification messages
* Compact canvas toolbar labels
* Tooltip-based shortcut hints

## Repository text normalization

Added `.gitattributes` to normalize line endings for source and package files.
